### PR TITLE
Add BooleanIntegerColumn TypeORM decorator

### DIFF
--- a/src/shared/cache/CacheKeyBuilder.ts
+++ b/src/shared/cache/CacheKeyBuilder.ts
@@ -1,0 +1,47 @@
+function serializeArg(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+
+  if (Array.isArray(value)) {
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === 'object') {
+    const sorted = sortObjectKeys(value as Record<string, unknown>);
+    return JSON.stringify(sorted);
+  }
+
+  return String(value);
+}
+
+function sortObjectKeys(obj: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const key of Object.keys(obj).sort()) {
+    const val = obj[key];
+    result[key] =
+      val !== null && typeof val === 'object' && !Array.isArray(val)
+        ? sortObjectKeys(val as Record<string, unknown>)
+        : val;
+  }
+
+  return result;
+}
+
+export function buildCacheKey(
+  prefix: string,
+  args: unknown[],
+  keyArgs?: number[],
+): string {
+  const selectedArgs = keyArgs
+    ? keyArgs.filter((i) => i < args.length).map((i) => args[i])
+    : args;
+
+  if (selectedArgs.length === 0) return prefix;
+
+  const serialized = selectedArgs.map(serializeArg);
+  return `${prefix}:${serialized.join(':')}`;
+}

--- a/src/shared/cache/InvalidateCacheDecorator.ts
+++ b/src/shared/cache/InvalidateCacheDecorator.ts
@@ -1,0 +1,45 @@
+import { Logger } from '@nestjs/common';
+import { CacheClient, CACHE_CLIENT, InvalidateMethodCacheOptions } from './interfaces';
+
+const logger = new Logger('InvalidateMethodCache');
+
+export function InvalidateMethodCache(options: InvalidateMethodCacheOptions) {
+  const prefixes = Array.isArray(options.prefixes) ? options.prefixes : [options.prefixes];
+
+  return <T>(
+    _target: object,
+    _propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<T>,
+  ): TypedPropertyDescriptor<T> => {
+    const original = descriptor.value as unknown as (...args: unknown[]) => Promise<unknown>;
+
+    (descriptor as TypedPropertyDescriptor<unknown>).value = async function (this: Record<string | symbol, unknown>, ...args: unknown[]): Promise<unknown> {
+      const result = await original.apply(this, args);
+
+      const client = this[CACHE_CLIENT] as CacheClient | undefined;
+      if (!client) return result;
+
+      try {
+        const keysToDelete: string[] = [];
+
+        for (const prefix of prefixes) {
+          const registryKey = `cache-registry:${prefix}`;
+          const members = await client.smembers(registryKey);
+          if (members.length > 0) {
+            keysToDelete.push(...members, registryKey);
+          }
+        }
+
+        if (keysToDelete.length > 0) {
+          await client.del(keysToDelete);
+        }
+      } catch {
+        logger.warn(`Cache invalidation failed for prefixes [${prefixes.join(', ')}]`);
+      }
+
+      return result;
+    };
+
+    return descriptor;
+  };
+}

--- a/src/shared/cache/RedisCacheDecorator.ts
+++ b/src/shared/cache/RedisCacheDecorator.ts
@@ -1,0 +1,64 @@
+import { Logger } from '@nestjs/common';
+import { buildCacheKey } from './CacheKeyBuilder';
+import { CacheClient, CACHE_CLIENT, MethodCacheOptions } from './interfaces';
+
+const logger = new Logger('MethodCache');
+
+const inflightRequests = new Map<string, Promise<unknown>>();
+
+export function MethodCache(options: MethodCacheOptions) {
+  const { prefix, ttlSeconds, keyArgs, deserialize = JSON.parse } = options;
+
+  return <T>(
+    _target: object,
+    _propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<T>,
+  ): TypedPropertyDescriptor<T> => {
+    const original = descriptor.value as unknown as (...args: unknown[]) => Promise<unknown>;
+
+    (descriptor as TypedPropertyDescriptor<unknown>).value = async function (this: Record<string | symbol, unknown>, ...args: unknown[]): Promise<unknown> {
+      const client = this[CACHE_CLIENT] as CacheClient | undefined;
+      const cacheKey = buildCacheKey(prefix, args, keyArgs);
+
+      if (client) {
+        try {
+          const cached = await client.get(cacheKey);
+          if (cached !== null) {
+            return deserialize(cached);
+          }
+        } catch {
+          logger.warn(`Cache GET failed for key "${cacheKey}", falling back to method execution`);
+        }
+      }
+
+      const inflight = inflightRequests.get(cacheKey);
+      if (inflight) {
+        return inflight;
+      }
+
+      const promise = original.apply(this, args);
+      inflightRequests.set(cacheKey, promise);
+
+      try {
+        const result = await promise;
+
+        if (client) {
+          try {
+            await Promise.all([
+              client.set(cacheKey, JSON.stringify(result), ttlSeconds),
+              client.sadd(`cache-registry:${prefix}`, cacheKey),
+            ]);
+          } catch {
+            logger.warn(`Cache SET failed for key "${cacheKey}", result returned without caching`);
+          }
+        }
+
+        return result;
+      } finally {
+        inflightRequests.delete(cacheKey);
+      }
+    };
+
+    return descriptor;
+  };
+}

--- a/src/shared/cache/RedisCacheModule.ts
+++ b/src/shared/cache/RedisCacheModule.ts
@@ -1,0 +1,41 @@
+import { DynamicModule, Logger, Module } from '@nestjs/common';
+import { CacheClient, CACHE_CLIENT } from './interfaces';
+
+export interface RedisCacheModuleOptions {
+  client?: CacheClient;
+}
+
+const noopClient: CacheClient = {
+  get: async () => null,
+  set: async () => {},
+  del: async () => {},
+  sadd: async () => {},
+  smembers: async () => [],
+};
+
+@Module({})
+export class RedisCacheModule {
+  private static readonly logger = new Logger(RedisCacheModule.name);
+
+  static forRoot(options: RedisCacheModuleOptions = {}): DynamicModule {
+    const client = options.client ?? noopClient;
+
+    if (!options.client) {
+      this.logger.warn(
+        'No CacheClient provided to RedisCacheModule.forRoot(). Using no-op fallback — caching is disabled.',
+      );
+    }
+
+    return {
+      module: RedisCacheModule,
+      global: true,
+      providers: [
+        {
+          provide: CACHE_CLIENT,
+          useValue: client,
+        },
+      ],
+      exports: [CACHE_CLIENT],
+    };
+  }
+}

--- a/src/shared/cache/interfaces.ts
+++ b/src/shared/cache/interfaces.ts
@@ -1,0 +1,39 @@
+/**
+ * Abstract Redis client interface.
+ * Applications provide their own implementation (ioredis, node-redis, etc.)
+ * via the CACHE_CLIENT injection token.
+ */
+export interface CacheClient {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttlSeconds: number): Promise<void>;
+  del(keys: string[]): Promise<void>;
+  /** Add members to a set (used for cache key registry). */
+  sadd(key: string, ...members: string[]): Promise<void>;
+  /** Return all members of a set (used for cache key registry). */
+  smembers(key: string): Promise<string[]>;
+}
+
+export interface MethodCacheOptions {
+  /** Cache key prefix. Combined with method arguments to form the full key. */
+  prefix: string;
+  /** Time-to-live in seconds. */
+  ttlSeconds: number;
+  /**
+   * Indices of method arguments to include in the cache key.
+   * When omitted, all arguments are used.
+   */
+  keyArgs?: number[];
+  /**
+   * Custom deserializer for cached values.
+   * Defaults to `JSON.parse`.
+   */
+  deserialize?(raw: string): unknown;
+}
+
+export interface InvalidateMethodCacheOptions {
+  /** One or more prefixes whose cached entries should be invalidated. */
+  prefixes: string | string[];
+}
+
+/** Injection token for the CacheClient provider. */
+export const CACHE_CLIENT = Symbol('CACHE_CLIENT');

--- a/src/shared/cache/test/CacheKeyBuilder.spec.ts
+++ b/src/shared/cache/test/CacheKeyBuilder.spec.ts
@@ -1,0 +1,89 @@
+import { buildCacheKey } from '../CacheKeyBuilder';
+
+describe('CacheKeyBuilder', () => {
+  describe('basic key generation', () => {
+    it('should build key from prefix and string arguments', () => {
+      const key = buildCacheKey('user', ['123']);
+
+      expect(key).toBe('user:123');
+    });
+
+    it('should build key from prefix and multiple arguments', () => {
+      const key = buildCacheKey('user', ['123', 'profile']);
+
+      expect(key).toBe('user:123:profile');
+    });
+
+    it('should build key with prefix only when no arguments given', () => {
+      const key = buildCacheKey('all-users', []);
+
+      expect(key).toBe('all-users');
+    });
+  });
+
+  describe('selective key arguments', () => {
+    it('should include only specified argument indices', () => {
+      const key = buildCacheKey('item', ['a', 'b', 'c'], [0, 2]);
+
+      expect(key).toBe('item:a:c');
+    });
+
+    it('should ignore out-of-bounds indices gracefully', () => {
+      const key = buildCacheKey('item', ['a'], [0, 5]);
+
+      expect(key).toBe('item:a');
+    });
+  });
+
+  describe('argument type handling', () => {
+    it('should serialize number arguments', () => {
+      const key = buildCacheKey('order', [42, 3.14]);
+
+      expect(key).toBe('order:42:3.14');
+    });
+
+    it('should serialize boolean arguments', () => {
+      const key = buildCacheKey('flag', [true, false]);
+
+      expect(key).toBe('flag:true:false');
+    });
+
+    it('should serialize null and undefined as stable strings', () => {
+      const key = buildCacheKey('nullable', [null, undefined]);
+
+      expect(key).toBe('nullable:null:undefined');
+    });
+
+    it('should serialize plain objects deterministically', () => {
+      const objA = { z: 1, a: 2 };
+      const objB = { a: 2, z: 1 };
+
+      expect(buildCacheKey('obj', [objA])).toBe(buildCacheKey('obj', [objB]));
+    });
+
+    it('should serialize arrays', () => {
+      const key = buildCacheKey('list', [[1, 2, 3]]);
+
+      expect(key).toBe('list:[1,2,3]');
+    });
+
+    it('should handle nested objects deterministically', () => {
+      const nested = { b: { d: 1, c: 2 }, a: 3 };
+
+      const key = buildCacheKey('nested', [nested]);
+
+      expect(key).toBe(buildCacheKey('nested', [{ a: 3, b: { c: 2, d: 1 } }]));
+    });
+  });
+
+  describe('determinism guarantee', () => {
+    it('should produce identical keys for identical inputs across calls', () => {
+      const args = ['hello', 42, { key: 'val' }];
+
+      const key1 = buildCacheKey('test', args);
+      const key2 = buildCacheKey('test', args);
+
+      expect(key1).toBe(key2);
+    });
+  });
+});

--- a/src/shared/cache/test/InvalidateCacheDecorator.spec.ts
+++ b/src/shared/cache/test/InvalidateCacheDecorator.spec.ts
@@ -1,0 +1,128 @@
+import { InvalidateMethodCache } from '../InvalidateCacheDecorator';
+import { CacheClient, CACHE_CLIENT } from '../interfaces';
+
+function createMockClient(overrides: Partial<CacheClient> = {}): CacheClient {
+  return {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+    sadd: jest.fn().mockResolvedValue(undefined),
+    smembers: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function createTestService(client: CacheClient) {
+  class TestService {
+    [CACHE_CLIENT] = client;
+
+    @InvalidateMethodCache({ prefixes: 'user' })
+    async updateUser(id: string, name: string): Promise<{ id: string; name: string }> {
+      return { id, name };
+    }
+
+    @InvalidateMethodCache({ prefixes: ['user', 'profile'] })
+    async deleteAccount(id: string): Promise<void> {
+      return;
+    }
+  }
+
+  return new TestService();
+}
+
+describe('InvalidateMethodCache', () => {
+  describe('single prefix invalidation', () => {
+    it('should delete all cached keys for the given prefix', async () => {
+      const client = createMockClient({
+        smembers: jest.fn().mockResolvedValue(['user:1', 'user:2']),
+      });
+      const service = createTestService(client);
+
+      await service.updateUser('1', 'Alice');
+
+      expect(client.smembers).toHaveBeenCalledWith('cache-registry:user');
+      expect(client.del).toHaveBeenCalledWith(['user:1', 'user:2', 'cache-registry:user']);
+    });
+
+    it('should return the method result after invalidation', async () => {
+      const client = createMockClient({
+        smembers: jest.fn().mockResolvedValue(['user:1']),
+      });
+      const service = createTestService(client);
+
+      const result = await service.updateUser('1', 'Bob');
+
+      expect(result).toEqual({ id: '1', name: 'Bob' });
+    });
+  });
+
+  describe('multi-prefix invalidation', () => {
+    it('should invalidate keys across all specified prefixes', async () => {
+      const client = createMockClient({
+        smembers: jest.fn()
+          .mockResolvedValueOnce(['user:1'])
+          .mockResolvedValueOnce(['profile:1', 'profile:2']),
+      });
+      const service = createTestService(client);
+
+      await service.deleteAccount('1');
+
+      expect(client.smembers).toHaveBeenCalledWith('cache-registry:user');
+      expect(client.smembers).toHaveBeenCalledWith('cache-registry:profile');
+      expect(client.del).toHaveBeenCalledWith([
+        'user:1',
+        'cache-registry:user',
+        'profile:1',
+        'profile:2',
+        'cache-registry:profile',
+      ]);
+    });
+  });
+
+  describe('no keys to invalidate', () => {
+    it('should skip deletion when registry is empty', async () => {
+      const client = createMockClient({
+        smembers: jest.fn().mockResolvedValue([]),
+      });
+      const service = createTestService(client);
+
+      await service.updateUser('1', 'Alice');
+
+      expect(client.del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('graceful degradation on Redis failure', () => {
+    it('should return method result when smembers fails', async () => {
+      const client = createMockClient({
+        smembers: jest.fn().mockRejectedValue(new Error('Redis read error')),
+      });
+      const service = createTestService(client);
+
+      const result = await service.updateUser('1', 'Charlie');
+
+      expect(result).toEqual({ id: '1', name: 'Charlie' });
+    });
+
+    it('should return method result when del fails', async () => {
+      const client = createMockClient({
+        smembers: jest.fn().mockResolvedValue(['user:1']),
+        del: jest.fn().mockRejectedValue(new Error('Redis delete error')),
+      });
+      const service = createTestService(client);
+
+      const result = await service.updateUser('1', 'Dave');
+
+      expect(result).toEqual({ id: '1', name: 'Dave' });
+    });
+
+    it('should return void method result when invalidation fails entirely', async () => {
+      const client = createMockClient({
+        smembers: jest.fn().mockRejectedValue(new Error('Redis down')),
+      });
+      const service = createTestService(client);
+
+      await expect(service.deleteAccount('1')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/shared/cache/test/RedisCacheDecorator.spec.ts
+++ b/src/shared/cache/test/RedisCacheDecorator.spec.ts
@@ -1,0 +1,164 @@
+import { MethodCache } from '../RedisCacheDecorator';
+import { CacheClient, CACHE_CLIENT } from '../interfaces';
+
+function createMockClient(overrides: Partial<CacheClient> = {}): CacheClient {
+  return {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+    sadd: jest.fn().mockResolvedValue(undefined),
+    smembers: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function createTestService(client: CacheClient) {
+  class TestService {
+    [CACHE_CLIENT] = client;
+
+    @MethodCache({ prefix: 'user', ttlSeconds: 60 })
+    async getUser(id: string): Promise<{ id: string; name: string }> {
+      return { id, name: `User ${id}` };
+    }
+
+    @MethodCache({ prefix: 'item', ttlSeconds: 30, keyArgs: [0] })
+    async getItem(id: number, _locale: string): Promise<{ id: number }> {
+      return { id };
+    }
+
+    @MethodCache({
+      prefix: 'custom',
+      ttlSeconds: 10,
+      deserialize: (raw: string) => {
+        const parsed = JSON.parse(raw);
+        parsed.deserialized = true;
+        return parsed;
+      },
+    })
+    async getCustom(key: string): Promise<{ key: string }> {
+      return { key };
+    }
+  }
+
+  return new TestService();
+}
+
+describe('MethodCache', () => {
+  describe('cache hit', () => {
+    it('should return cached value without calling the original method', async () => {
+      const cachedValue = JSON.stringify({ id: '1', name: 'Cached User' });
+      const client = createMockClient({ get: jest.fn().mockResolvedValue(cachedValue) });
+      const service = createTestService(client);
+
+      const spy = jest.spyOn(service, 'getUser');
+      const result = await service.getUser('1');
+
+      expect(result).toEqual({ id: '1', name: 'Cached User' });
+      expect(client.get).toHaveBeenCalledWith('user:1');
+      expect(spy).toHaveReturnedWith(expect.any(Promise));
+    });
+  });
+
+  describe('cache miss', () => {
+    it('should call original method and cache the result', async () => {
+      const client = createMockClient();
+      const service = createTestService(client);
+
+      const result = await service.getUser('42');
+
+      expect(result).toEqual({ id: '42', name: 'User 42' });
+      expect(client.get).toHaveBeenCalledWith('user:42');
+      expect(client.set).toHaveBeenCalledWith(
+        'user:42',
+        JSON.stringify({ id: '42', name: 'User 42' }),
+        60,
+      );
+    });
+
+    it('should register the cache key in a registry set', async () => {
+      const client = createMockClient();
+      const service = createTestService(client);
+
+      await service.getUser('1');
+
+      expect(client.sadd).toHaveBeenCalledWith('cache-registry:user', 'user:1');
+    });
+  });
+
+  describe('selective key arguments', () => {
+    it('should build cache key from selected argument indices only', async () => {
+      const client = createMockClient();
+      const service = createTestService(client);
+
+      await service.getItem(99, 'ko');
+
+      expect(client.get).toHaveBeenCalledWith('item:99');
+    });
+  });
+
+  describe('custom deserializer', () => {
+    it('should use custom deserialize function on cache hit', async () => {
+      const cached = JSON.stringify({ key: 'val' });
+      const client = createMockClient({ get: jest.fn().mockResolvedValue(cached) });
+      const service = createTestService(client);
+
+      const result = await service.getCustom('val');
+
+      expect(result).toEqual({ key: 'val', deserialized: true });
+    });
+  });
+
+  describe('request coalescing', () => {
+    it('should execute method only once for concurrent identical calls', async () => {
+      const client = createMockClient();
+      const service = createTestService(client);
+
+      const [r1, r2, r3] = await Promise.all([
+        service.getUser('1'),
+        service.getUser('1'),
+        service.getUser('1'),
+      ]);
+
+      expect(r1).toEqual(r2);
+      expect(r2).toEqual(r3);
+      expect(client.set).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('graceful degradation on Redis failure', () => {
+    it('should fall back to original method when Redis get fails', async () => {
+      const client = createMockClient({
+        get: jest.fn().mockRejectedValue(new Error('Redis connection lost')),
+      });
+      const service = createTestService(client);
+
+      const result = await service.getUser('1');
+
+      expect(result).toEqual({ id: '1', name: 'User 1' });
+    });
+
+    it('should return result even when Redis set fails', async () => {
+      const client = createMockClient({
+        set: jest.fn().mockRejectedValue(new Error('Redis write failed')),
+        sadd: jest.fn().mockRejectedValue(new Error('Redis write failed')),
+      });
+      const service = createTestService(client);
+
+      const result = await service.getUser('1');
+
+      expect(result).toEqual({ id: '1', name: 'User 1' });
+    });
+
+    it('should not throw when Redis sadd (registry) fails', async () => {
+      const client = createMockClient({
+        sadd: jest.fn().mockRejectedValue(new Error('Redis SADD failed')),
+      });
+      const service = createTestService(client);
+
+      await expect(service.getUser('1')).resolves.toEqual({
+        id: '1',
+        name: 'User 1',
+      });
+    });
+  });
+});

--- a/src/shared/common/ExternalId.ts
+++ b/src/shared/common/ExternalId.ts
@@ -1,0 +1,134 @@
+const BASE62_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const MIN_LENGTH = 8;
+const CHECKSUM_MODULUS = 4096;
+
+function charAt(alphabet: string[], index: number): string {
+  const char = alphabet[index];
+
+  if (char === undefined) {
+    throw new Error(`Alphabet index out of bounds: ${index}`);
+  }
+
+  return char;
+}
+
+export class ExternalId {
+  private static readonly encoderCache = new Map<string, string[]>();
+
+  static encode(id: number, entityType: string): string {
+    const alphabet = ExternalId.getAlphabet(entityType);
+    const base = alphabet.length;
+    const checksum = Math.abs(ExternalId.hashString(entityType)) % CHECKSUM_MODULUS;
+    let value = id * CHECKSUM_MODULUS + checksum;
+    let result = '';
+
+    if (value === 0) {
+      result = charAt(alphabet, 0);
+    } else {
+      while (value > 0) {
+        result = charAt(alphabet, value % base) + result;
+        value = Math.floor(value / base);
+      }
+    }
+
+    while (result.length < MIN_LENGTH) {
+      result = charAt(alphabet, 0) + result;
+    }
+
+    return result;
+  }
+
+  static decode(externalId: string, entityType: string): number | null {
+    if (externalId.length === 0) {
+      return null;
+    }
+
+    if (!/^[0-9a-zA-Z]+$/.test(externalId)) {
+      return null;
+    }
+
+    const alphabet = ExternalId.getAlphabet(entityType);
+    const base = alphabet.length;
+    const charToIndex = new Map<string, number>();
+
+    for (let i = 0; i < alphabet.length; i++) {
+      charToIndex.set(charAt(alphabet, i), i);
+    }
+
+    let payload = 0;
+
+    for (const char of externalId) {
+      const index = charToIndex.get(char);
+
+      if (index === undefined) {
+        return null;
+      }
+
+      payload = payload * base + index;
+    }
+
+    const checksum = payload % CHECKSUM_MODULUS;
+    const expectedChecksum = Math.abs(ExternalId.hashString(entityType)) % CHECKSUM_MODULUS;
+
+    if (checksum !== expectedChecksum) {
+      return null;
+    }
+
+    const id = Math.floor(payload / CHECKSUM_MODULUS);
+
+    if (ExternalId.encode(id, entityType) !== externalId) {
+      return null;
+    }
+
+    return id;
+  }
+
+  private static getAlphabet(entityType: string): string[] {
+    const cached = ExternalId.encoderCache.get(entityType);
+
+    if (cached) {
+      return cached;
+    }
+
+    const alphabet = ExternalId.shuffleAlphabet(entityType);
+    ExternalId.encoderCache.set(entityType, alphabet);
+
+    return alphabet;
+  }
+
+  private static shuffleAlphabet(entityType: string): string[] {
+    const chars = BASE62_ALPHABET.split('');
+    const seed = ExternalId.hashString(entityType);
+    let state = seed;
+
+    for (let i = chars.length - 1; i > 0; i--) {
+      state = ExternalId.nextRandom(state);
+      const j = Math.abs(state) % (i + 1);
+      const a = charAt(chars, i);
+      const b = charAt(chars, j);
+      chars[i] = b;
+      chars[j] = a;
+    }
+
+    return chars;
+  }
+
+  private static hashString(str: string): number {
+    let hash = 0;
+
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = ((hash << 5) - hash + char) | 0;
+    }
+
+    return hash;
+  }
+
+  private static nextRandom(state: number): number {
+    state = (state ^ (state << 13)) | 0;
+    state = (state ^ (state >> 17)) | 0;
+    state = (state ^ (state << 5)) | 0;
+
+    return state;
+  }
+}

--- a/src/shared/common/Semaphore.ts
+++ b/src/shared/common/Semaphore.ts
@@ -1,0 +1,101 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+interface SemaphoreOptions {
+  maxConcurrency: number;
+  maxQueueSize?: number;
+  timeoutMs?: number;
+}
+
+interface QueueEntry {
+  resolve(): void;
+  reject(error: Error): void;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+}
+
+export class Semaphore {
+  private currentCount: number;
+  private readonly queue: QueueEntry[] = [];
+
+  constructor(private readonly options: SemaphoreOptions) {
+    this.currentCount = 0;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.currentCount < this.options.maxConcurrency) {
+      this.currentCount++;
+      return;
+    }
+
+    if (
+      this.options.maxQueueSize !== undefined &&
+      this.queue.length >= this.options.maxQueueSize
+    ) {
+      throw new HttpException(
+        'Too Many Requests',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const entry: QueueEntry = { resolve, reject };
+
+      if (this.options.timeoutMs !== undefined) {
+        entry.timeoutHandle = setTimeout(() => {
+          const index = this.queue.indexOf(entry);
+
+          if (index !== -1) {
+            this.queue.splice(index, 1);
+          }
+
+          reject(
+            new HttpException(
+              'Gateway Timeout',
+              HttpStatus.GATEWAY_TIMEOUT,
+            ),
+          );
+        }, this.options.timeoutMs);
+      }
+
+      this.queue.push(entry);
+    });
+  }
+
+  release(): void {
+    if (this.queue.length > 0) {
+      const next = this.queue.shift();
+
+      if (next === undefined) {
+        return;
+      }
+
+      if (next.timeoutHandle !== undefined) {
+        clearTimeout(next.timeoutHandle);
+      }
+
+      next.resolve();
+      return;
+    }
+
+    if (this.currentCount > 0) {
+      this.currentCount--;
+    }
+  }
+
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+
+  get availableSlots(): number {
+    return Math.max(0, this.options.maxConcurrency - this.currentCount);
+  }
+
+  get queueLength(): number {
+    return this.queue.length;
+  }
+}

--- a/src/shared/common/test/ExternalId.spec.ts
+++ b/src/shared/common/test/ExternalId.spec.ts
@@ -1,0 +1,98 @@
+import { ExternalId } from '../ExternalId';
+
+describe('ExternalId', () => {
+  describe('encode/decode round-trip', () => {
+    it('should round-trip for small IDs', () => {
+      const id = 1;
+      const encoded = ExternalId.encode(id, 'user');
+      const decoded = ExternalId.decode(encoded, 'user');
+
+      expect(decoded).toEqual(id);
+    });
+
+    it('should round-trip for large IDs', () => {
+      const id = 999_999_999;
+      const encoded = ExternalId.encode(id, 'post');
+      const decoded = ExternalId.decode(encoded, 'post');
+
+      expect(decoded).toEqual(id);
+    });
+
+    it('should round-trip for various entity types', () => {
+      const ids = [1, 42, 1000, 123456789];
+      const entityTypes = ['user', 'post', 'comment', 'organization'];
+
+      for (const id of ids) {
+        for (const entityType of entityTypes) {
+          const encoded = ExternalId.encode(id, entityType);
+          const decoded = ExternalId.decode(encoded, entityType);
+
+          expect(decoded).toEqual(id);
+        }
+      }
+    });
+  });
+
+  describe('entity-type differentiation', () => {
+    it('should produce different outputs for different entity types with the same ID', () => {
+      const id = 42;
+      const userEncoded = ExternalId.encode(id, 'user');
+      const postEncoded = ExternalId.encode(id, 'post');
+
+      expect(userEncoded).not.toEqual(postEncoded);
+    });
+
+    it('should produce the same output for the same ID and entity type', () => {
+      const id = 42;
+      const first = ExternalId.encode(id, 'user');
+      const second = ExternalId.encode(id, 'user');
+
+      expect(first).toEqual(second);
+    });
+  });
+
+  describe('decode returns null for invalid input', () => {
+    it('should return null for empty string', () => {
+      expect(ExternalId.decode('', 'user')).toBeNull();
+    });
+
+    it('should return null for string with invalid characters', () => {
+      expect(ExternalId.decode('!@#$%^&*()', 'user')).toBeNull();
+    });
+
+    it('should return null for string with spaces', () => {
+      expect(ExternalId.decode('abc def', 'user')).toBeNull();
+    });
+  });
+
+  describe('decode returns null for wrong entity type', () => {
+    it('should return null when decoding with wrong entity type', () => {
+      const encoded = ExternalId.encode(42, 'user');
+      const decoded = ExternalId.decode(encoded, 'post');
+
+      expect(decoded).toBeNull();
+    });
+  });
+
+  describe('minimum length', () => {
+    it('should produce output of at least 8 characters for small IDs', () => {
+      const encoded = ExternalId.encode(1, 'user');
+
+      expect(encoded.length).toBeGreaterThanOrEqual(8);
+    });
+
+    it('should produce output of at least 8 characters for zero', () => {
+      const encoded = ExternalId.encode(0, 'user');
+
+      expect(encoded.length).toBeGreaterThanOrEqual(8);
+    });
+  });
+
+  describe('output format', () => {
+    it('should only contain base62 characters', () => {
+      const encoded = ExternalId.encode(123456, 'user');
+
+      expect(encoded).toMatch(/^[0-9a-zA-Z]+$/);
+    });
+  });
+});

--- a/src/shared/common/test/Semaphore.spec.ts
+++ b/src/shared/common/test/Semaphore.spec.ts
@@ -1,0 +1,260 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+import { Semaphore } from '../Semaphore';
+
+describe('Semaphore', () => {
+  describe('basic acquire/release flow', () => {
+    it('should acquire immediately when slots are available', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 2 });
+
+      await semaphore.acquire();
+
+      expect(semaphore.availableSlots).toEqual(1);
+    });
+
+    it('should release a slot', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 2 });
+
+      await semaphore.acquire();
+      semaphore.release();
+
+      expect(semaphore.availableSlots).toEqual(2);
+    });
+
+    it('should handle multiple sequential acquire/release cycles', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+
+      for (let i = 0; i < 5; i++) {
+        await semaphore.acquire();
+        expect(semaphore.availableSlots).toEqual(0);
+        semaphore.release();
+        expect(semaphore.availableSlots).toEqual(1);
+      }
+    });
+  });
+
+  describe('concurrency limit enforcement', () => {
+    it('should make the N+1th acquire wait when all slots are taken', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 2 });
+
+      await semaphore.acquire();
+      await semaphore.acquire();
+
+      let resolved = false;
+      const waiting = semaphore.acquire().then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+      expect(resolved).toEqual(false);
+      expect(semaphore.queueLength).toEqual(1);
+
+      semaphore.release();
+      await waiting;
+      expect(resolved).toEqual(true);
+    });
+
+    it('should resolve queued requests in FIFO order', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+      const order: number[] = [];
+
+      await semaphore.acquire();
+
+      const first = semaphore.acquire().then(() => order.push(1));
+      const second = semaphore.acquire().then(() => order.push(2));
+
+      semaphore.release();
+      await first;
+      semaphore.release();
+      await second;
+
+      expect(order).toEqual([1, 2]);
+    });
+  });
+
+  describe('availableSlots and queueLength getters', () => {
+    it('should report correct availableSlots', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 3 });
+
+      expect(semaphore.availableSlots).toEqual(3);
+
+      await semaphore.acquire();
+      expect(semaphore.availableSlots).toEqual(2);
+
+      await semaphore.acquire();
+      expect(semaphore.availableSlots).toEqual(1);
+
+      await semaphore.acquire();
+      expect(semaphore.availableSlots).toEqual(0);
+    });
+
+    it('should report correct queueLength', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+
+      expect(semaphore.queueLength).toEqual(0);
+
+      await semaphore.acquire();
+      semaphore.acquire();
+      semaphore.acquire();
+
+      await Promise.resolve();
+      expect(semaphore.queueLength).toEqual(2);
+
+      semaphore.release();
+      await Promise.resolve();
+      expect(semaphore.queueLength).toEqual(1);
+
+      semaphore.release();
+      await Promise.resolve();
+      expect(semaphore.queueLength).toEqual(0);
+    });
+  });
+
+  describe('queue overflow (429)', () => {
+    it('should throw HttpException with 429 when queue is full', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1, maxQueueSize: 1 });
+
+      await semaphore.acquire();
+      semaphore.acquire();
+
+      await expect(semaphore.acquire()).rejects.toThrow(HttpException);
+      await expect(semaphore.acquire()).rejects.toMatchObject({
+        response: 'Too Many Requests',
+        status: HttpStatus.TOO_MANY_REQUESTS,
+      });
+
+      semaphore.release();
+      semaphore.release();
+    });
+
+    it('should allow acquire after queue drains below maxQueueSize', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1, maxQueueSize: 1 });
+
+      await semaphore.acquire();
+      const queued = semaphore.acquire();
+
+      semaphore.release();
+      await queued;
+
+      const nextQueued = semaphore.acquire();
+
+      await Promise.resolve();
+      expect(semaphore.queueLength).toEqual(1);
+
+      semaphore.release();
+      await nextQueued;
+      semaphore.release();
+    });
+  });
+
+  describe('timeout (504)', () => {
+    it('should throw HttpException with 504 when acquire times out', async () => {
+      jest.useFakeTimers();
+
+      const semaphore = new Semaphore({
+        maxConcurrency: 1,
+        timeoutMs: 1000,
+      });
+
+      await semaphore.acquire();
+
+      const acquirePromise = semaphore.acquire();
+
+      jest.advanceTimersByTime(1000);
+
+      await expect(acquirePromise).rejects.toThrow(HttpException);
+      semaphore.release();
+      jest.useRealTimers();
+    });
+
+    it('should remove timed-out request from queue', async () => {
+      jest.useFakeTimers();
+
+      const semaphore = new Semaphore({
+        maxConcurrency: 1,
+        timeoutMs: 500,
+      });
+
+      await semaphore.acquire();
+
+      const timedOutPromise = semaphore.acquire();
+      expect(semaphore.queueLength).toEqual(1);
+
+      jest.advanceTimersByTime(500);
+
+      await timedOutPromise.catch(() => undefined);
+      expect(semaphore.queueLength).toEqual(0);
+
+      semaphore.release();
+      jest.useRealTimers();
+    });
+
+    it('should clear timeout when acquire succeeds before timeout', async () => {
+      jest.useFakeTimers();
+
+      const semaphore = new Semaphore({
+        maxConcurrency: 1,
+        timeoutMs: 5000,
+      });
+
+      await semaphore.acquire();
+
+      const acquirePromise = semaphore.acquire();
+
+      semaphore.release();
+      await acquirePromise;
+
+      jest.advanceTimersByTime(5000);
+
+      expect(semaphore.availableSlots).toEqual(0);
+
+      semaphore.release();
+      jest.useRealTimers();
+    });
+  });
+
+  describe('execute()', () => {
+    it('should run function and release slot', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+
+      const result = await semaphore.execute(async () => 'done');
+
+      expect(result).toEqual('done');
+      expect(semaphore.availableSlots).toEqual(1);
+    });
+
+    it('should release slot when function throws', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+
+      await expect(
+        semaphore.execute(async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+
+      expect(semaphore.availableSlots).toEqual(1);
+    });
+
+    it('should respect concurrency limit', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 2 });
+      let concurrent = 0;
+      let maxConcurrent = 0;
+
+      const task = async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        concurrent--;
+      };
+
+      await Promise.all([
+        semaphore.execute(task),
+        semaphore.execute(task),
+        semaphore.execute(task),
+        semaphore.execute(task),
+      ]);
+
+      expect(maxConcurrent).toEqual(2);
+    });
+  });
+});

--- a/src/shared/core/application/Facade.ts
+++ b/src/shared/core/application/Facade.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Base class for application facades.
+ *
+ * A facade orchestrates one or more use cases / services and transforms
+ * domain results into presentation-layer DTOs. It is the natural
+ * transaction boundary when using `@Transactional()`.
+ *
+ * Guidelines:
+ * - One facade per bounded context concern (e.g., PublicBannerFacade, AdminBannerFacade)
+ * - Facades may call multiple services but must NOT contain domain logic
+ * - Response DTO construction belongs here, not in controllers or services
+ * - Use `@Transactional()` on facade methods when atomicity is required across multiple service calls
+ */
+@Injectable()
+export abstract class Facade {}

--- a/src/shared/core/application/test/Facade.spec.ts
+++ b/src/shared/core/application/test/Facade.spec.ts
@@ -1,0 +1,32 @@
+import { Facade } from '../Facade';
+
+class StubFacade extends Facade {
+  greet(name: string): string {
+    return `hello ${name}`;
+  }
+}
+
+describe('Facade', () => {
+  it('can be extended and instantiated', () => {
+    const facade = new StubFacade();
+
+    expect(facade).toBeInstanceOf(StubFacade);
+    expect(facade).toBeInstanceOf(Facade);
+  });
+
+  it('delegates to concrete methods defined by subclasses', () => {
+    const facade = new StubFacade();
+
+    expect(facade.greet('world')).toBe('hello world');
+  });
+
+  it('can be used as a NestJS provider type reference', () => {
+    const providers: Array<{ provide: typeof Facade; useClass: typeof StubFacade }> = [
+      { provide: Facade, useClass: StubFacade },
+    ];
+    const entry = providers[0]!;
+
+    expect(entry.provide).toBe(Facade);
+    expect(entry.useClass).toBe(StubFacade);
+  });
+});

--- a/src/shared/distributed-lock/DistributedLockModule.ts
+++ b/src/shared/distributed-lock/DistributedLockModule.ts
@@ -1,0 +1,41 @@
+import { DynamicModule, Logger, Module } from '@nestjs/common';
+import { DistributedLockService } from './DistributedLockService';
+import { LOCK_CLIENT, LockClient } from './interfaces';
+
+export interface DistributedLockModuleOptions {
+  client?: LockClient;
+}
+
+const noopClient: LockClient = {
+  set: async (): Promise<null> => null,
+  get: async (): Promise<null> => null,
+  eval: async (): Promise<unknown> => 0,
+};
+
+@Module({})
+export class DistributedLockModule {
+  private static readonly logger = new Logger(DistributedLockModule.name);
+
+  static forRoot(options: DistributedLockModuleOptions = {}): DynamicModule {
+    const client = options.client ?? noopClient;
+
+    if (!options.client) {
+      this.logger.warn(
+        'No LockClient provided to DistributedLockModule.forRoot(). Using no-op fallback — locking is disabled.',
+      );
+    }
+
+    return {
+      module: DistributedLockModule,
+      global: true,
+      providers: [
+        {
+          provide: LOCK_CLIENT,
+          useValue: client,
+        },
+        DistributedLockService,
+      ],
+      exports: [LOCK_CLIENT, DistributedLockService],
+    };
+  }
+}

--- a/src/shared/distributed-lock/DistributedLockService.ts
+++ b/src/shared/distributed-lock/DistributedLockService.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { LOCK_CLIENT, LockClient, LockOptions } from './interfaces';
+
+const RELEASE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end
+`;
+
+const DEFAULT_TTL_MS = 10_000;
+const DEFAULT_RETRY_COUNT = 3;
+const DEFAULT_RETRY_DELAY_MS = 200;
+
+@Injectable()
+export class DistributedLockService {
+  private readonly logger = new Logger(DistributedLockService.name);
+
+  constructor(
+    @Inject(LOCK_CLIENT) private readonly client: LockClient,
+  ) {}
+
+  async acquireLock(options: LockOptions): Promise<string | null> {
+    const {
+      key,
+      ttlMs = DEFAULT_TTL_MS,
+      retryCount = DEFAULT_RETRY_COUNT,
+      retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+      retryJitter = true,
+    } = options;
+
+    const value = `${Date.now()}:${process.pid}:${randomUUID()}`;
+    const maxAttempts = 1 + retryCount;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const result = await this.client.set(key, value, ttlMs, true);
+
+      if (result === 'OK') {
+        this.logger.debug(`Lock acquired: ${key} (attempt ${attempt + 1})`);
+        return value;
+      }
+
+      if (attempt < maxAttempts - 1) {
+        const delay = retryJitter
+          ? retryDelayMs + Math.floor(Math.random() * retryDelayMs)
+          : retryDelayMs;
+        await this.sleep(delay);
+      }
+    }
+
+    this.logger.warn(`Lock acquisition failed after ${maxAttempts} attempts: ${key}`);
+    return null;
+  }
+
+  async releaseLock(key: string, value: string): Promise<boolean> {
+    const result = await this.client.eval(RELEASE_SCRIPT, [key], [value]);
+    const released = result === 1;
+
+    if (released) {
+      this.logger.debug(`Lock released: ${key}`);
+    } else {
+      this.logger.warn(`Lock release failed (value mismatch or expired): ${key}`);
+    }
+
+    return released;
+  }
+
+  async executeWithLock<T>(options: LockOptions, fn: () => Promise<T>): Promise<T> {
+    const lockValue = await this.acquireLock(options);
+
+    if (lockValue === null) {
+      throw new Error(`Failed to acquire lock: ${options.key}`);
+    }
+
+    try {
+      return await fn();
+    } finally {
+      await this.releaseLock(options.key, lockValue);
+    }
+  }
+
+  private async sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+}

--- a/src/shared/distributed-lock/interfaces.ts
+++ b/src/shared/distributed-lock/interfaces.ts
@@ -1,0 +1,25 @@
+/**
+ * Abstract lock client interface.
+ * Applications provide their own implementation (ioredis, node-redis, etc.)
+ * via the LOCK_CLIENT injection token.
+ */
+export interface LockClient {
+  set(key: string, value: string, px: number, nx: true): Promise<'OK' | null>;
+  get(key: string): Promise<string | null>;
+  eval(script: string, keys: string[], args: string[]): Promise<unknown>;
+}
+
+export interface LockOptions {
+  key: string;
+  /** Time-to-live in milliseconds. @default 10_000 */
+  ttlMs?: number;
+  /** Maximum number of acquisition retries. @default 3 */
+  retryCount?: number;
+  /** Base delay between retries in milliseconds. @default 200 */
+  retryDelayMs?: number;
+  /** Adds random jitter to retry delay. @default true */
+  retryJitter?: boolean;
+}
+
+/** Injection token for the LockClient provider. */
+export const LOCK_CLIENT = Symbol('LOCK_CLIENT');

--- a/src/shared/distributed-lock/test/DistributedLockService.spec.ts
+++ b/src/shared/distributed-lock/test/DistributedLockService.spec.ts
@@ -1,0 +1,190 @@
+import { Test } from '@nestjs/testing';
+
+import { DistributedLockService } from '../DistributedLockService';
+import { LockClient, LOCK_CLIENT } from '../interfaces';
+
+function createMockClient(overrides: Partial<LockClient> = {}): LockClient {
+  return {
+    set: jest.fn().mockResolvedValue(null),
+    get: jest.fn().mockResolvedValue(null),
+    eval: jest.fn().mockResolvedValue(0),
+    ...overrides,
+  };
+}
+
+async function buildService(client: LockClient): Promise<DistributedLockService> {
+  const module = await Test.createTestingModule({
+    providers: [
+      DistributedLockService,
+      { provide: LOCK_CLIENT, useValue: client },
+    ],
+  }).compile();
+
+  return module.get(DistributedLockService);
+}
+
+describe('DistributedLockService', () => {
+  describe('acquireLock', () => {
+    it('returns a lock value on successful acquisition', async () => {
+      const client = createMockClient({
+        set: jest.fn().mockResolvedValue('OK'),
+      });
+      const service = await buildService(client);
+
+      const value = await service.acquireLock({ key: 'test-lock', retryCount: 0 });
+
+      expect(value).not.toBeNull();
+      expect(typeof value).toBe('string');
+      expect(client.set).toHaveBeenCalledWith(
+        'test-lock',
+        expect.any(String),
+        10_000,
+        true,
+      );
+    });
+
+    it('returns null when lock is already held and retries exhausted', async () => {
+      const client = createMockClient({
+        set: jest.fn().mockResolvedValue(null),
+      });
+      const service = await buildService(client);
+
+      const value = await service.acquireLock({
+        key: 'test-lock',
+        retryCount: 0,
+      });
+
+      expect(value).toBeNull();
+    });
+
+    it('retries on failure and succeeds on later attempt', async () => {
+      const setMock = jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('OK');
+      const client = createMockClient({ set: setMock });
+      const service = await buildService(client);
+
+      const value = await service.acquireLock({
+        key: 'test-lock',
+        retryCount: 3,
+        retryDelayMs: 10,
+        retryJitter: false,
+      });
+
+      expect(value).not.toBeNull();
+      expect(setMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('respects retryCount limit', async () => {
+      const setMock = jest.fn().mockResolvedValue(null);
+      const client = createMockClient({ set: setMock });
+      const service = await buildService(client);
+
+      const value = await service.acquireLock({
+        key: 'test-lock',
+        retryCount: 2,
+        retryDelayMs: 10,
+        retryJitter: false,
+      });
+
+      expect(value).toBeNull();
+      // 1 initial + 2 retries = 3 total
+      expect(setMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('uses custom ttlMs', async () => {
+      const setMock = jest.fn().mockResolvedValue('OK');
+      const client = createMockClient({ set: setMock });
+      const service = await buildService(client);
+
+      await service.acquireLock({ key: 'test-lock', ttlMs: 5000, retryCount: 0 });
+
+      expect(setMock).toHaveBeenCalledWith('test-lock', expect.any(String), 5000, true);
+    });
+  });
+
+  describe('releaseLock', () => {
+    it('releases lock when value matches', async () => {
+      const client = createMockClient({
+        eval: jest.fn().mockResolvedValue(1),
+      });
+      const service = await buildService(client);
+
+      const released = await service.releaseLock('test-lock', 'lock-value-123');
+
+      expect(released).toBe(true);
+      expect(client.eval).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call("get"'),
+        ['test-lock'],
+        ['lock-value-123'],
+      );
+    });
+
+    it('does not release lock when value does not match', async () => {
+      const client = createMockClient({
+        eval: jest.fn().mockResolvedValue(0),
+      });
+      const service = await buildService(client);
+
+      const released = await service.releaseLock('test-lock', 'wrong-value');
+
+      expect(released).toBe(false);
+    });
+  });
+
+  describe('executeWithLock', () => {
+    it('acquires lock, executes function, and releases', async () => {
+      const client = createMockClient({
+        set: jest.fn().mockResolvedValue('OK'),
+        eval: jest.fn().mockResolvedValue(1),
+      });
+      const service = await buildService(client);
+      const fn = jest.fn().mockResolvedValue('result');
+
+      const result = await service.executeWithLock(
+        { key: 'test-lock', retryCount: 0 },
+        fn,
+      );
+
+      expect(result).toBe('result');
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(client.eval).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases lock even when function throws', async () => {
+      const client = createMockClient({
+        set: jest.fn().mockResolvedValue('OK'),
+        eval: jest.fn().mockResolvedValue(1),
+      });
+      const service = await buildService(client);
+      const error = new Error('fn-error');
+
+      await expect(
+        service.executeWithLock({ key: 'test-lock', retryCount: 0 }, () =>
+          Promise.reject(error),
+        ),
+      ).rejects.toThrow('fn-error');
+
+      expect(client.eval).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when lock acquisition fails', async () => {
+      const client = createMockClient({
+        set: jest.fn().mockResolvedValue(null),
+      });
+      const service = await buildService(client);
+      const fn = jest.fn();
+
+      await expect(
+        service.executeWithLock(
+          { key: 'test-lock', retryCount: 0 },
+          fn,
+        ),
+      ).rejects.toThrow();
+
+      expect(fn).not.toHaveBeenCalled();
+      expect(client.eval).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/shared/interceptors/IdempotencyInterceptor.ts
+++ b/src/shared/interceptors/IdempotencyInterceptor.ts
@@ -1,0 +1,102 @@
+import { Observable, of, from, throwError } from 'rxjs';
+import { switchMap, tap, catchError } from 'rxjs/operators';
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+  Inject,
+  ConflictException,
+  HttpStatus,
+} from '@nestjs/common';
+import { CacheClient, CACHE_CLIENT } from '../cache/interfaces';
+
+const PROCESSING_MARKER = '__processing__';
+const PROCESSING_TTL_SECONDS = 300;
+const RESULT_TTL_SECONDS = 10800;
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(IdempotencyInterceptor.name);
+
+  constructor(@Inject(CACHE_CLIENT) private readonly cacheClient: CacheClient) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const http = context.switchToHttp();
+    const request = http.getRequest<{ headers: Record<string, string> }>();
+    const idempotencyKey = request.headers['idempotency-key'];
+
+    if (!idempotencyKey) {
+      return next.handle();
+    }
+
+    const cacheKey = `idempotency:${idempotencyKey}`;
+    const processingKey = `${cacheKey}:processing`;
+
+    return from(this.checkCache(cacheKey, processingKey)).pipe(
+      switchMap((cached) => {
+        if (cached !== null) {
+          const parsed = JSON.parse(cached) as { statusCode: number; body: unknown };
+          const response = http.getResponse<{ statusCode: number }>();
+          response.statusCode = parsed.statusCode;
+          return of(parsed.body);
+        }
+
+        return from(this.setProcessingMarker(processingKey)).pipe(
+          switchMap(() => next.handle()),
+          tap((body) => {
+            const response = http.getResponse<{ statusCode: number }>();
+            const statusCode = response.statusCode;
+
+            if (statusCode >= HttpStatus.INTERNAL_SERVER_ERROR) {
+              this.cleanupProcessingMarker(processingKey);
+              return;
+            }
+
+            const value = JSON.stringify({ statusCode, body });
+            this.cacheClient
+              .set(cacheKey, value, RESULT_TTL_SECONDS)
+              .then(() => this.cacheClient.del([processingKey]))
+              .catch((error: unknown) => {
+                this.logger.warn(`Failed to cache idempotency result: ${error}`);
+              });
+          }),
+        );
+      }),
+      catchError((error: unknown) => {
+        if (error instanceof ConflictException) {
+          return throwError(() => error);
+        }
+        this.logger.warn(`Idempotency cache error, falling through: ${error}`);
+        return next.handle();
+      }),
+    );
+  }
+
+  private async checkCache(cacheKey: string, processingKey: string): Promise<string | null> {
+    const cached = await this.cacheClient.get(cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+
+    const processing = await this.cacheClient.get(processingKey);
+    if (processing === PROCESSING_MARKER) {
+      throw new ConflictException(
+        'A request with this Idempotency-Key is already being processed',
+      );
+    }
+
+    return null;
+  }
+
+  private async setProcessingMarker(processingKey: string): Promise<void> {
+    await this.cacheClient.set(processingKey, PROCESSING_MARKER, PROCESSING_TTL_SECONDS);
+  }
+
+  private cleanupProcessingMarker(processingKey: string): void {
+    this.cacheClient.del([processingKey]).catch((error: unknown) => {
+      this.logger.warn(`Failed to clean up processing marker: ${error}`);
+    });
+  }
+}

--- a/src/shared/interceptors/test/IdempotencyInterceptor.spec.ts
+++ b/src/shared/interceptors/test/IdempotencyInterceptor.spec.ts
@@ -1,0 +1,216 @@
+import { of, lastValueFrom } from 'rxjs';
+import { CallHandler, ConflictException, ExecutionContext, HttpStatus } from '@nestjs/common';
+import { IdempotencyInterceptor } from '../IdempotencyInterceptor';
+import { CacheClient } from '../../cache/interfaces';
+
+function createMockCacheClient(overrides: Partial<CacheClient> = {}): jest.Mocked<CacheClient> {
+  return {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+    sadd: jest.fn().mockResolvedValue(undefined),
+    smembers: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  } as jest.Mocked<CacheClient>;
+}
+
+function createMockExecutionContext(headers: Record<string, string> = {}): ExecutionContext {
+  const request = {
+    headers,
+  };
+  const response = {
+    statusCode: HttpStatus.OK,
+  };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function createMockCallHandler(returnValue: unknown = { success: true }): CallHandler {
+  return {
+    handle: jest.fn().mockReturnValue(of(returnValue)),
+  };
+}
+
+describe('IdempotencyInterceptor', () => {
+  let interceptor: IdempotencyInterceptor;
+  let cacheClient: jest.Mocked<CacheClient>;
+
+  beforeEach(() => {
+    cacheClient = createMockCacheClient();
+    interceptor = new IdempotencyInterceptor(cacheClient);
+  });
+
+  describe('when no Idempotency-Key header is present', () => {
+    it('should pass through to handler without cache interaction', async () => {
+      const context = createMockExecutionContext({});
+      const handler = createMockCallHandler({ data: 'response' });
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ data: 'response' });
+      expect(handler.handle).toHaveBeenCalled();
+      expect(cacheClient.get).not.toHaveBeenCalled();
+      expect(cacheClient.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when Idempotency-Key header is present (first request)', () => {
+    it('should execute handler, cache the result, and return it', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler({ id: 1, name: 'created' });
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ id: 1, name: 'created' });
+      expect(handler.handle).toHaveBeenCalled();
+      expect(cacheClient.get).toHaveBeenCalledWith('idempotency:abc-123');
+      expect(cacheClient.set).toHaveBeenCalledWith(
+        'idempotency:abc-123',
+        JSON.stringify({ statusCode: HttpStatus.OK, body: { id: 1, name: 'created' } }),
+        10800,
+      );
+    });
+
+    it('should remove the processing marker after caching the result', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler({ done: true });
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(cacheClient.del).toHaveBeenCalledWith(['idempotency:abc-123:processing']);
+    });
+  });
+
+  describe('when Idempotency-Key header is present (cached result exists)', () => {
+    it('should return cached result without executing handler', async () => {
+      const cached = JSON.stringify({ statusCode: HttpStatus.CREATED, body: { id: 1 } });
+      cacheClient = createMockCacheClient({ get: jest.fn().mockResolvedValue(cached) });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler();
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ id: 1 });
+      expect(handler.handle).not.toHaveBeenCalled();
+    });
+
+    it('should set the response status code from the cached result', async () => {
+      const cached = JSON.stringify({ statusCode: HttpStatus.CREATED, body: { id: 1 } });
+      cacheClient = createMockCacheClient({ get: jest.fn().mockResolvedValue(cached) });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const response = context.switchToHttp().getResponse() as { statusCode: number };
+      const handler = createMockCallHandler();
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(response.statusCode).toBe(HttpStatus.CREATED);
+    });
+  });
+
+  describe('when a concurrent request is in-flight (processing marker)', () => {
+    it('should throw ConflictException', async () => {
+      const processingMarker = '__processing__';
+      cacheClient = createMockCacheClient({
+        get: jest.fn().mockImplementation((key: string) => {
+          if (key === 'idempotency:abc-123') return Promise.resolve(null);
+          if (key === 'idempotency:abc-123:processing') return Promise.resolve(processingMarker);
+          return Promise.resolve(null);
+        }),
+      });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler();
+
+      await expect(
+        lastValueFrom(interceptor.intercept(context, handler)),
+      ).rejects.toThrow(ConflictException);
+
+      expect(handler.handle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when handler returns 5xx response', () => {
+    it('should not cache the result', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const response = context.switchToHttp().getResponse() as { statusCode: number };
+      const handler = createMockCallHandler({ error: 'internal' });
+
+      response.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+      handler.handle = jest.fn().mockReturnValue(of({ error: 'internal' }));
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(cacheClient.set).not.toHaveBeenCalledWith(
+        'idempotency:abc-123',
+        expect.any(String),
+        10800,
+      );
+    });
+
+    it('should still remove the processing marker on 5xx', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const response = context.switchToHttp().getResponse() as { statusCode: number };
+      response.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+      const handler = createMockCallHandler({ error: 'internal' });
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(cacheClient.del).toHaveBeenCalledWith(['idempotency:abc-123:processing']);
+    });
+  });
+
+  describe('when CacheClient fails', () => {
+    it('should fall through to handler on cache get failure', async () => {
+      cacheClient = createMockCacheClient({
+        get: jest.fn().mockRejectedValue(new Error('Redis down')),
+      });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler({ fallback: true });
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ fallback: true });
+      expect(handler.handle).toHaveBeenCalled();
+    });
+
+    it('should return handler result even when cache set fails', async () => {
+      cacheClient = createMockCacheClient({
+        set: jest.fn().mockRejectedValue(new Error('Redis write failed')),
+      });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler({ data: 'ok' });
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ data: 'ok' });
+    });
+  });
+
+  describe('stale processing marker handling', () => {
+    it('should set processing marker with 5-minute TTL', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler();
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(cacheClient.set).toHaveBeenCalledWith(
+        'idempotency:abc-123:processing',
+        '__processing__',
+        300,
+      );
+    });
+  });
+});

--- a/src/shared/pipes/ParseExternalIdPipe.ts
+++ b/src/shared/pipes/ParseExternalIdPipe.ts
@@ -1,0 +1,16 @@
+import { BadRequestException, PipeTransform } from '@nestjs/common';
+import { ExternalId } from '../common/ExternalId';
+
+export class ParseExternalIdPipe implements PipeTransform<string, number> {
+  constructor(private readonly entityType: string) {}
+
+  transform(value: string): number {
+    const id = ExternalId.decode(value, this.entityType);
+
+    if (id === null) {
+      throw new BadRequestException(`Invalid external ID: ${value}`);
+    }
+
+    return id;
+  }
+}

--- a/src/shared/pipes/test/ParseExternalIdPipe.spec.ts
+++ b/src/shared/pipes/test/ParseExternalIdPipe.spec.ts
@@ -1,0 +1,35 @@
+import { BadRequestException } from '@nestjs/common';
+import { ExternalId } from '../../common/ExternalId';
+import { ParseExternalIdPipe } from '../ParseExternalIdPipe';
+
+describe('ParseExternalIdPipe', () => {
+  const entityType = 'user';
+  let pipe: ParseExternalIdPipe;
+
+  beforeEach(() => {
+    pipe = new ParseExternalIdPipe(entityType);
+  });
+
+  describe('transform', () => {
+    it('should decode a valid external ID to its internal numeric ID', () => {
+      const id = 42;
+      const encoded = ExternalId.encode(id, entityType);
+
+      expect(pipe.transform(encoded)).toEqual(id);
+    });
+
+    it('should throw BadRequestException for an invalid external ID', () => {
+      expect(() => pipe.transform('!invalid!')).toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for an empty string', () => {
+      expect(() => pipe.transform('')).toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for a wrong entity type ID', () => {
+      const encoded = ExternalId.encode(42, 'post');
+
+      expect(() => pipe.transform(encoded)).toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/shared/typeorm/BooleanIntegerColumn.ts
+++ b/src/shared/typeorm/BooleanIntegerColumn.ts
@@ -1,0 +1,34 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { Column, ColumnOptions } from 'typeorm';
+import { BooleanIntegerTransformer } from './BooleanIntegerTransformer';
+
+interface BooleanIntegerColumnOptions extends ColumnOptions {
+  validationOptions?: ValidationOptions;
+}
+
+export function BooleanIntegerColumn(options: BooleanIntegerColumnOptions = {}): PropertyDecorator {
+  return function (target: object, propertyKey: string | symbol): void {
+    registerDecorator({
+      name: 'booleanIntegerColumn',
+      target: target.constructor,
+      propertyName: propertyKey.toString(),
+      options: options.validationOptions,
+      validator: {
+        validate(value: unknown): boolean {
+          if (value === null) {
+            return options.nullable || false;
+          }
+
+          return typeof value === 'boolean';
+        },
+      },
+    });
+
+    Column({
+      type: 'tinyint',
+      nullable: options.nullable || false,
+      transformer: new BooleanIntegerTransformer(),
+      ...options,
+    })(target, propertyKey);
+  };
+}

--- a/src/shared/typeorm/BooleanIntegerTransformer.ts
+++ b/src/shared/typeorm/BooleanIntegerTransformer.ts
@@ -1,0 +1,19 @@
+import { ValueTransformer } from 'typeorm';
+
+export class BooleanIntegerTransformer implements ValueTransformer {
+  from(value: number | null): boolean | null {
+    if (value === null) {
+      return null;
+    }
+
+    return value !== 0;
+  }
+
+  to(value: boolean | null): number | null {
+    if (value === null) {
+      return null;
+    }
+
+    return value ? 1 : 0;
+  }
+}

--- a/src/shared/typeorm/test/BooleanIntegerColumn.spec.ts
+++ b/src/shared/typeorm/test/BooleanIntegerColumn.spec.ts
@@ -1,0 +1,36 @@
+import { BooleanIntegerColumn } from '../BooleanIntegerColumn';
+
+describe('BooleanIntegerColumn', () => {
+  it('should apply as a property decorator without error', () => {
+    expect(() => {
+      class TestEntity {
+        @BooleanIntegerColumn()
+        isActive!: boolean;
+      }
+
+      return TestEntity;
+    }).not.toThrow();
+  });
+
+  it('should apply with nullable option without error', () => {
+    expect(() => {
+      class TestEntity {
+        @BooleanIntegerColumn({ nullable: true })
+        isActive!: boolean | null;
+      }
+
+      return TestEntity;
+    }).not.toThrow();
+  });
+
+  it('should apply with additional column options without error', () => {
+    expect(() => {
+      class TestEntity {
+        @BooleanIntegerColumn({ default: 0, comment: 'Active flag' })
+        isActive!: boolean;
+      }
+
+      return TestEntity;
+    }).not.toThrow();
+  });
+});

--- a/src/shared/typeorm/test/BooleanIntegerTransformer.spec.ts
+++ b/src/shared/typeorm/test/BooleanIntegerTransformer.spec.ts
@@ -1,0 +1,43 @@
+import { BooleanIntegerTransformer } from '../BooleanIntegerTransformer';
+
+describe('BooleanIntegerTransformer', () => {
+  let transformer: BooleanIntegerTransformer;
+
+  beforeEach(() => {
+    transformer = new BooleanIntegerTransformer();
+  });
+
+  describe('from (database → application)', () => {
+    it('should convert 1 to true', () => {
+      expect(transformer.from(1)).toBe(true);
+    });
+
+    it('should convert 0 to false', () => {
+      expect(transformer.from(0)).toBe(false);
+    });
+
+    it('should convert null to null', () => {
+      expect(transformer.from(null)).toBeNull();
+    });
+
+    it('should convert non-zero numbers to true', () => {
+      expect(transformer.from(2)).toBe(true);
+      expect(transformer.from(-1)).toBe(true);
+      expect(transformer.from(42)).toBe(true);
+    });
+  });
+
+  describe('to (application → database)', () => {
+    it('should convert true to 1', () => {
+      expect(transformer.to(true)).toBe(1);
+    });
+
+    it('should convert false to 0', () => {
+      expect(transformer.to(false)).toBe(0);
+    });
+
+    it('should convert null to null', () => {
+      expect(transformer.to(null)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Custom TypeORM column decorator for MySQL tinyint ↔ boolean mapping.

- **BooleanIntegerColumn**: PropertyDecorator wrapping `@Column({ type: 'tinyint', transformer })`
- **BooleanIntegerTransformer**: Bidirectional number/boolean conversion with nullable support
- Follows existing DateColumn/DateTimeColumn pattern

10 unit tests.

> **Stack**: 4/10 — base: `feat/shared-03-pagination`