### PR TITLE
Add IdempotencyInterceptor for request deduplication

### DIFF
--- a/src/shared/common/Semaphore.ts
+++ b/src/shared/common/Semaphore.ts
@@ -1,0 +1,101 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+interface SemaphoreOptions {
+  maxConcurrency: number;
+  maxQueueSize?: number;
+  timeoutMs?: number;
+}
+
+interface QueueEntry {
+  resolve(): void;
+  reject(error: Error): void;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+}
+
+export class Semaphore {
+  private currentCount: number;
+  private readonly queue: QueueEntry[] = [];
+
+  constructor(private readonly options: SemaphoreOptions) {
+    this.currentCount = 0;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.currentCount < this.options.maxConcurrency) {
+      this.currentCount++;
+      return;
+    }
+
+    if (
+      this.options.maxQueueSize !== undefined &&
+      this.queue.length >= this.options.maxQueueSize
+    ) {
+      throw new HttpException(
+        'Too Many Requests',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const entry: QueueEntry = { resolve, reject };
+
+      if (this.options.timeoutMs !== undefined) {
+        entry.timeoutHandle = setTimeout(() => {
+          const index = this.queue.indexOf(entry);
+
+          if (index !== -1) {
+            this.queue.splice(index, 1);
+          }
+
+          reject(
+            new HttpException(
+              'Gateway Timeout',
+              HttpStatus.GATEWAY_TIMEOUT,
+            ),
+          );
+        }, this.options.timeoutMs);
+      }
+
+      this.queue.push(entry);
+    });
+  }
+
+  release(): void {
+    if (this.queue.length > 0) {
+      const next = this.queue.shift();
+
+      if (next === undefined) {
+        return;
+      }
+
+      if (next.timeoutHandle !== undefined) {
+        clearTimeout(next.timeoutHandle);
+      }
+
+      next.resolve();
+      return;
+    }
+
+    if (this.currentCount > 0) {
+      this.currentCount--;
+    }
+  }
+
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+
+  get availableSlots(): number {
+    return Math.max(0, this.options.maxConcurrency - this.currentCount);
+  }
+
+  get queueLength(): number {
+    return this.queue.length;
+  }
+}

--- a/src/shared/common/test/Semaphore.spec.ts
+++ b/src/shared/common/test/Semaphore.spec.ts
@@ -1,0 +1,260 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+import { Semaphore } from '../Semaphore';
+
+describe('Semaphore', () => {
+  describe('basic acquire/release flow', () => {
+    it('should acquire immediately when slots are available', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 2 });
+
+      await semaphore.acquire();
+
+      expect(semaphore.availableSlots).toEqual(1);
+    });
+
+    it('should release a slot', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 2 });
+
+      await semaphore.acquire();
+      semaphore.release();
+
+      expect(semaphore.availableSlots).toEqual(2);
+    });
+
+    it('should handle multiple sequential acquire/release cycles', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+
+      for (let i = 0; i < 5; i++) {
+        await semaphore.acquire();
+        expect(semaphore.availableSlots).toEqual(0);
+        semaphore.release();
+        expect(semaphore.availableSlots).toEqual(1);
+      }
+    });
+  });
+
+  describe('concurrency limit enforcement', () => {
+    it('should make the N+1th acquire wait when all slots are taken', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 2 });
+
+      await semaphore.acquire();
+      await semaphore.acquire();
+
+      let resolved = false;
+      const waiting = semaphore.acquire().then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+      expect(resolved).toEqual(false);
+      expect(semaphore.queueLength).toEqual(1);
+
+      semaphore.release();
+      await waiting;
+      expect(resolved).toEqual(true);
+    });
+
+    it('should resolve queued requests in FIFO order', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+      const order: number[] = [];
+
+      await semaphore.acquire();
+
+      const first = semaphore.acquire().then(() => order.push(1));
+      const second = semaphore.acquire().then(() => order.push(2));
+
+      semaphore.release();
+      await first;
+      semaphore.release();
+      await second;
+
+      expect(order).toEqual([1, 2]);
+    });
+  });
+
+  describe('availableSlots and queueLength getters', () => {
+    it('should report correct availableSlots', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 3 });
+
+      expect(semaphore.availableSlots).toEqual(3);
+
+      await semaphore.acquire();
+      expect(semaphore.availableSlots).toEqual(2);
+
+      await semaphore.acquire();
+      expect(semaphore.availableSlots).toEqual(1);
+
+      await semaphore.acquire();
+      expect(semaphore.availableSlots).toEqual(0);
+    });
+
+    it('should report correct queueLength', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+
+      expect(semaphore.queueLength).toEqual(0);
+
+      await semaphore.acquire();
+      semaphore.acquire();
+      semaphore.acquire();
+
+      await Promise.resolve();
+      expect(semaphore.queueLength).toEqual(2);
+
+      semaphore.release();
+      await Promise.resolve();
+      expect(semaphore.queueLength).toEqual(1);
+
+      semaphore.release();
+      await Promise.resolve();
+      expect(semaphore.queueLength).toEqual(0);
+    });
+  });
+
+  describe('queue overflow (429)', () => {
+    it('should throw HttpException with 429 when queue is full', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1, maxQueueSize: 1 });
+
+      await semaphore.acquire();
+      semaphore.acquire();
+
+      await expect(semaphore.acquire()).rejects.toThrow(HttpException);
+      await expect(semaphore.acquire()).rejects.toMatchObject({
+        response: 'Too Many Requests',
+        status: HttpStatus.TOO_MANY_REQUESTS,
+      });
+
+      semaphore.release();
+      semaphore.release();
+    });
+
+    it('should allow acquire after queue drains below maxQueueSize', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1, maxQueueSize: 1 });
+
+      await semaphore.acquire();
+      const queued = semaphore.acquire();
+
+      semaphore.release();
+      await queued;
+
+      const nextQueued = semaphore.acquire();
+
+      await Promise.resolve();
+      expect(semaphore.queueLength).toEqual(1);
+
+      semaphore.release();
+      await nextQueued;
+      semaphore.release();
+    });
+  });
+
+  describe('timeout (504)', () => {
+    it('should throw HttpException with 504 when acquire times out', async () => {
+      jest.useFakeTimers();
+
+      const semaphore = new Semaphore({
+        maxConcurrency: 1,
+        timeoutMs: 1000,
+      });
+
+      await semaphore.acquire();
+
+      const acquirePromise = semaphore.acquire();
+
+      jest.advanceTimersByTime(1000);
+
+      await expect(acquirePromise).rejects.toThrow(HttpException);
+      semaphore.release();
+      jest.useRealTimers();
+    });
+
+    it('should remove timed-out request from queue', async () => {
+      jest.useFakeTimers();
+
+      const semaphore = new Semaphore({
+        maxConcurrency: 1,
+        timeoutMs: 500,
+      });
+
+      await semaphore.acquire();
+
+      const timedOutPromise = semaphore.acquire();
+      expect(semaphore.queueLength).toEqual(1);
+
+      jest.advanceTimersByTime(500);
+
+      await timedOutPromise.catch(() => undefined);
+      expect(semaphore.queueLength).toEqual(0);
+
+      semaphore.release();
+      jest.useRealTimers();
+    });
+
+    it('should clear timeout when acquire succeeds before timeout', async () => {
+      jest.useFakeTimers();
+
+      const semaphore = new Semaphore({
+        maxConcurrency: 1,
+        timeoutMs: 5000,
+      });
+
+      await semaphore.acquire();
+
+      const acquirePromise = semaphore.acquire();
+
+      semaphore.release();
+      await acquirePromise;
+
+      jest.advanceTimersByTime(5000);
+
+      expect(semaphore.availableSlots).toEqual(0);
+
+      semaphore.release();
+      jest.useRealTimers();
+    });
+  });
+
+  describe('execute()', () => {
+    it('should run function and release slot', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+
+      const result = await semaphore.execute(async () => 'done');
+
+      expect(result).toEqual('done');
+      expect(semaphore.availableSlots).toEqual(1);
+    });
+
+    it('should release slot when function throws', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 1 });
+
+      await expect(
+        semaphore.execute(async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+
+      expect(semaphore.availableSlots).toEqual(1);
+    });
+
+    it('should respect concurrency limit', async () => {
+      const semaphore = new Semaphore({ maxConcurrency: 2 });
+      let concurrent = 0;
+      let maxConcurrent = 0;
+
+      const task = async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        concurrent--;
+      };
+
+      await Promise.all([
+        semaphore.execute(task),
+        semaphore.execute(task),
+        semaphore.execute(task),
+        semaphore.execute(task),
+      ]);
+
+      expect(maxConcurrent).toEqual(2);
+    });
+  });
+});

--- a/src/shared/interceptors/IdempotencyInterceptor.ts
+++ b/src/shared/interceptors/IdempotencyInterceptor.ts
@@ -1,0 +1,102 @@
+import { Observable, of, from, throwError } from 'rxjs';
+import { switchMap, tap, catchError } from 'rxjs/operators';
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+  Inject,
+  ConflictException,
+  HttpStatus,
+} from '@nestjs/common';
+import { CacheClient, CACHE_CLIENT } from '../cache/interfaces';
+
+const PROCESSING_MARKER = '__processing__';
+const PROCESSING_TTL_SECONDS = 300;
+const RESULT_TTL_SECONDS = 10800;
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(IdempotencyInterceptor.name);
+
+  constructor(@Inject(CACHE_CLIENT) private readonly cacheClient: CacheClient) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const http = context.switchToHttp();
+    const request = http.getRequest<{ headers: Record<string, string> }>();
+    const idempotencyKey = request.headers['idempotency-key'];
+
+    if (!idempotencyKey) {
+      return next.handle();
+    }
+
+    const cacheKey = `idempotency:${idempotencyKey}`;
+    const processingKey = `${cacheKey}:processing`;
+
+    return from(this.checkCache(cacheKey, processingKey)).pipe(
+      switchMap((cached) => {
+        if (cached !== null) {
+          const parsed = JSON.parse(cached) as { statusCode: number; body: unknown };
+          const response = http.getResponse<{ statusCode: number }>();
+          response.statusCode = parsed.statusCode;
+          return of(parsed.body);
+        }
+
+        return from(this.setProcessingMarker(processingKey)).pipe(
+          switchMap(() => next.handle()),
+          tap((body) => {
+            const response = http.getResponse<{ statusCode: number }>();
+            const statusCode = response.statusCode;
+
+            if (statusCode >= HttpStatus.INTERNAL_SERVER_ERROR) {
+              this.cleanupProcessingMarker(processingKey);
+              return;
+            }
+
+            const value = JSON.stringify({ statusCode, body });
+            this.cacheClient
+              .set(cacheKey, value, RESULT_TTL_SECONDS)
+              .then(() => this.cacheClient.del([processingKey]))
+              .catch((error: unknown) => {
+                this.logger.warn(`Failed to cache idempotency result: ${error}`);
+              });
+          }),
+        );
+      }),
+      catchError((error: unknown) => {
+        if (error instanceof ConflictException) {
+          return throwError(() => error);
+        }
+        this.logger.warn(`Idempotency cache error, falling through: ${error}`);
+        return next.handle();
+      }),
+    );
+  }
+
+  private async checkCache(cacheKey: string, processingKey: string): Promise<string | null> {
+    const cached = await this.cacheClient.get(cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+
+    const processing = await this.cacheClient.get(processingKey);
+    if (processing === PROCESSING_MARKER) {
+      throw new ConflictException(
+        'A request with this Idempotency-Key is already being processed',
+      );
+    }
+
+    return null;
+  }
+
+  private async setProcessingMarker(processingKey: string): Promise<void> {
+    await this.cacheClient.set(processingKey, PROCESSING_MARKER, PROCESSING_TTL_SECONDS);
+  }
+
+  private cleanupProcessingMarker(processingKey: string): void {
+    this.cacheClient.del([processingKey]).catch((error: unknown) => {
+      this.logger.warn(`Failed to clean up processing marker: ${error}`);
+    });
+  }
+}

--- a/src/shared/interceptors/test/IdempotencyInterceptor.spec.ts
+++ b/src/shared/interceptors/test/IdempotencyInterceptor.spec.ts
@@ -1,0 +1,216 @@
+import { of, lastValueFrom } from 'rxjs';
+import { CallHandler, ConflictException, ExecutionContext, HttpStatus } from '@nestjs/common';
+import { IdempotencyInterceptor } from '../IdempotencyInterceptor';
+import { CacheClient } from '../../cache/interfaces';
+
+function createMockCacheClient(overrides: Partial<CacheClient> = {}): jest.Mocked<CacheClient> {
+  return {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+    sadd: jest.fn().mockResolvedValue(undefined),
+    smembers: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  } as jest.Mocked<CacheClient>;
+}
+
+function createMockExecutionContext(headers: Record<string, string> = {}): ExecutionContext {
+  const request = {
+    headers,
+  };
+  const response = {
+    statusCode: HttpStatus.OK,
+  };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function createMockCallHandler(returnValue: unknown = { success: true }): CallHandler {
+  return {
+    handle: jest.fn().mockReturnValue(of(returnValue)),
+  };
+}
+
+describe('IdempotencyInterceptor', () => {
+  let interceptor: IdempotencyInterceptor;
+  let cacheClient: jest.Mocked<CacheClient>;
+
+  beforeEach(() => {
+    cacheClient = createMockCacheClient();
+    interceptor = new IdempotencyInterceptor(cacheClient);
+  });
+
+  describe('when no Idempotency-Key header is present', () => {
+    it('should pass through to handler without cache interaction', async () => {
+      const context = createMockExecutionContext({});
+      const handler = createMockCallHandler({ data: 'response' });
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ data: 'response' });
+      expect(handler.handle).toHaveBeenCalled();
+      expect(cacheClient.get).not.toHaveBeenCalled();
+      expect(cacheClient.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when Idempotency-Key header is present (first request)', () => {
+    it('should execute handler, cache the result, and return it', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler({ id: 1, name: 'created' });
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ id: 1, name: 'created' });
+      expect(handler.handle).toHaveBeenCalled();
+      expect(cacheClient.get).toHaveBeenCalledWith('idempotency:abc-123');
+      expect(cacheClient.set).toHaveBeenCalledWith(
+        'idempotency:abc-123',
+        JSON.stringify({ statusCode: HttpStatus.OK, body: { id: 1, name: 'created' } }),
+        10800,
+      );
+    });
+
+    it('should remove the processing marker after caching the result', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler({ done: true });
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(cacheClient.del).toHaveBeenCalledWith(['idempotency:abc-123:processing']);
+    });
+  });
+
+  describe('when Idempotency-Key header is present (cached result exists)', () => {
+    it('should return cached result without executing handler', async () => {
+      const cached = JSON.stringify({ statusCode: HttpStatus.CREATED, body: { id: 1 } });
+      cacheClient = createMockCacheClient({ get: jest.fn().mockResolvedValue(cached) });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler();
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ id: 1 });
+      expect(handler.handle).not.toHaveBeenCalled();
+    });
+
+    it('should set the response status code from the cached result', async () => {
+      const cached = JSON.stringify({ statusCode: HttpStatus.CREATED, body: { id: 1 } });
+      cacheClient = createMockCacheClient({ get: jest.fn().mockResolvedValue(cached) });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const response = context.switchToHttp().getResponse() as { statusCode: number };
+      const handler = createMockCallHandler();
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(response.statusCode).toBe(HttpStatus.CREATED);
+    });
+  });
+
+  describe('when a concurrent request is in-flight (processing marker)', () => {
+    it('should throw ConflictException', async () => {
+      const processingMarker = '__processing__';
+      cacheClient = createMockCacheClient({
+        get: jest.fn().mockImplementation((key: string) => {
+          if (key === 'idempotency:abc-123') return Promise.resolve(null);
+          if (key === 'idempotency:abc-123:processing') return Promise.resolve(processingMarker);
+          return Promise.resolve(null);
+        }),
+      });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler();
+
+      await expect(
+        lastValueFrom(interceptor.intercept(context, handler)),
+      ).rejects.toThrow(ConflictException);
+
+      expect(handler.handle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when handler returns 5xx response', () => {
+    it('should not cache the result', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const response = context.switchToHttp().getResponse() as { statusCode: number };
+      const handler = createMockCallHandler({ error: 'internal' });
+
+      response.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+      handler.handle = jest.fn().mockReturnValue(of({ error: 'internal' }));
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(cacheClient.set).not.toHaveBeenCalledWith(
+        'idempotency:abc-123',
+        expect.any(String),
+        10800,
+      );
+    });
+
+    it('should still remove the processing marker on 5xx', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const response = context.switchToHttp().getResponse() as { statusCode: number };
+      response.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+      const handler = createMockCallHandler({ error: 'internal' });
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(cacheClient.del).toHaveBeenCalledWith(['idempotency:abc-123:processing']);
+    });
+  });
+
+  describe('when CacheClient fails', () => {
+    it('should fall through to handler on cache get failure', async () => {
+      cacheClient = createMockCacheClient({
+        get: jest.fn().mockRejectedValue(new Error('Redis down')),
+      });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler({ fallback: true });
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ fallback: true });
+      expect(handler.handle).toHaveBeenCalled();
+    });
+
+    it('should return handler result even when cache set fails', async () => {
+      cacheClient = createMockCacheClient({
+        set: jest.fn().mockRejectedValue(new Error('Redis write failed')),
+      });
+      interceptor = new IdempotencyInterceptor(cacheClient);
+
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler({ data: 'ok' });
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(result).toEqual({ data: 'ok' });
+    });
+  });
+
+  describe('stale processing marker handling', () => {
+    it('should set processing marker with 5-minute TTL', async () => {
+      const context = createMockExecutionContext({ 'idempotency-key': 'abc-123' });
+      const handler = createMockCallHandler();
+
+      await lastValueFrom(interceptor.intercept(context, handler));
+
+      expect(cacheClient.set).toHaveBeenCalledWith(
+        'idempotency:abc-123:processing',
+        '__processing__',
+        300,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Ensures mutation endpoint idempotency via `Idempotency-Key` header.

- Redis-backed with existing CacheClient abstraction (reuses cache module)
- Processing marker (5min TTL) detects concurrent duplicate requests → 409 Conflict
- Result caching (3hr TTL) returns cached response for retries
- 5xx responses excluded from cache to allow retries
- Graceful degradation on cache failure — passes through to handler

11 unit tests.

> **Stack**: 9/10 — base: `feat/shared-08-distributed-lock`