### PR TITLE
Add CoreResponseInterceptor for standardized response envelope

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import helmet from 'helmet';
 import { ValidationPipe } from '@nestjs/common';
 import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { AllExceptionsFilter } from '@shared/filters/AllExceptionsFilter';
+import { CoreResponseInterceptor } from '@shared/interceptors/CoreResponseInterceptor';
 import { HttpLoggingInterceptor } from '@shared/interceptors/HttpLoggingInterceptor';
 import CLIENT_URL_WHITELIST from '@shared/config/ClientURLWhitelist';
 import { IS_PRODUCTION } from '@shared/config/config';
@@ -19,7 +20,7 @@ async function bootstrap(): Promise<void> {
 
   const httpAdapterHost = app.get(HttpAdapterHost);
   app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost));
-  app.useGlobalInterceptors(new HttpLoggingInterceptor());
+  app.useGlobalInterceptors(new CoreResponseInterceptor(), new HttpLoggingInterceptor());
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/src/shared/interceptors/CoreResponseInterceptor.ts
+++ b/src/shared/interceptors/CoreResponseInterceptor.ts
@@ -1,0 +1,33 @@
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { CallHandler, ExecutionContext, HttpStatus, Injectable, NestInterceptor } from '@nestjs/common';
+import { TRACE_ID_HEADER_KEY } from '../middlewares/TraceIdIssuanceMiddleware';
+
+@Injectable()
+export class CoreResponseInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(
+      map((data) => {
+        const ctx = context.switchToHttp();
+        const request = ctx.getRequest();
+        const response = ctx.getResponse();
+        const statusCode: number = response.statusCode;
+
+        if (statusCode === HttpStatus.NO_CONTENT) {
+          return data;
+        }
+
+        const traceId = request.headers[TRACE_ID_HEADER_KEY] || '';
+
+        return {
+          traceId,
+          statusCode,
+          timestamp: new Date().toISOString(),
+          path: request.originalUrl,
+          ok: true,
+          result: data ?? {},
+        };
+      }),
+    );
+  }
+}

--- a/src/shared/interceptors/test/CoreResponseInterceptor.spec.ts
+++ b/src/shared/interceptors/test/CoreResponseInterceptor.spec.ts
@@ -1,0 +1,187 @@
+import { of, lastValueFrom } from 'rxjs';
+import { CallHandler, ExecutionContext, HttpStatus } from '@nestjs/common';
+import { CoreResponseInterceptor } from '../CoreResponseInterceptor';
+import { TRACE_ID_HEADER_KEY } from '../../middlewares/TraceIdIssuanceMiddleware';
+
+function createMockExecutionContext(options: {
+  method?: string;
+  url?: string;
+  statusCode?: number;
+  traceId?: string;
+}): ExecutionContext {
+  const { method = 'GET', url = '/api/test', statusCode = 200, traceId = '' } = options;
+  const request = {
+    method,
+    originalUrl: url,
+    headers: {
+      [TRACE_ID_HEADER_KEY]: traceId,
+    },
+  };
+  const response = { statusCode };
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function createMockCallHandler(returnValue: unknown = { success: true }): CallHandler {
+  return {
+    handle: jest.fn().mockReturnValue(of(returnValue)),
+  };
+}
+
+describe('CoreResponseInterceptor', () => {
+  let interceptor: CoreResponseInterceptor;
+
+  beforeEach(() => {
+    interceptor = new CoreResponseInterceptor();
+  });
+
+  it('should return an Observable', () => {
+    const context = createMockExecutionContext({});
+    const handler = createMockCallHandler();
+
+    const result = interceptor.intercept(context, handler);
+
+    expect(result).toBeDefined();
+    expect(typeof result.subscribe).toBe('function');
+  });
+
+  it('should wrap response with envelope fields', async () => {
+    const context = createMockExecutionContext({
+      method: 'GET',
+      url: '/api/users',
+      statusCode: 200,
+      traceId: 'trace-123',
+    });
+    const handler = createMockCallHandler({ id: 1, name: 'Alice' });
+
+    const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+    expect(result).toMatchObject({
+      traceId: 'trace-123',
+      statusCode: 200,
+      path: '/api/users',
+      ok: true,
+      result: { id: 1, name: 'Alice' },
+    });
+  });
+
+  it('should include a timestamp in ISO 8601 format', async () => {
+    const context = createMockExecutionContext({ statusCode: 200 });
+    const handler = createMockCallHandler({});
+
+    const result = (await lastValueFrom(interceptor.intercept(context, handler))) as Record<string, unknown>;
+
+    expect(typeof result['timestamp']).toBe('string');
+    expect(new Date(result['timestamp'] as string).toISOString()).toBe(result['timestamp']);
+  });
+
+  it('should preserve original data inside result', async () => {
+    const data = { items: [1, 2, 3], total: 3 };
+    const context = createMockExecutionContext({ statusCode: 200 });
+    const handler = createMockCallHandler(data);
+
+    const result = (await lastValueFrom(interceptor.intercept(context, handler))) as Record<string, unknown>;
+
+    expect(result['result']).toEqual(data);
+  });
+
+  it('should skip wrapping for 204 No Content and return data as-is', async () => {
+    const context = createMockExecutionContext({ statusCode: HttpStatus.NO_CONTENT });
+    const handler = createMockCallHandler(null);
+
+    const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null as-is for 204 No Content when handler returns null', async () => {
+    const context = createMockExecutionContext({ statusCode: HttpStatus.NO_CONTENT });
+    const handler = createMockCallHandler(null);
+
+    const result = await lastValueFrom(interceptor.intercept(context, handler));
+
+    expect(result).toBeNull();
+  });
+
+  it('should default result to {} when data is null', async () => {
+    const context = createMockExecutionContext({ statusCode: 200 });
+    const handler = createMockCallHandler(null);
+
+    const result = (await lastValueFrom(interceptor.intercept(context, handler))) as Record<string, unknown>;
+
+    expect(result['result']).toEqual({});
+    expect(result['ok']).toBe(true);
+  });
+
+  it('should default result to {} when data is undefined', async () => {
+    const context = createMockExecutionContext({ statusCode: 200 });
+    const handler: CallHandler = {
+      handle: jest.fn().mockReturnValue(of(undefined as unknown as null)),
+    };
+
+    const result = (await lastValueFrom(interceptor.intercept(context, handler))) as Record<string, unknown>;
+
+    expect(result['result']).toEqual({});
+    expect(result['ok']).toBe(true);
+  });
+
+  it('should use traceId from request headers', async () => {
+    const context = createMockExecutionContext({ traceId: 'my-trace-id-456', statusCode: 200 });
+    const handler = createMockCallHandler({});
+
+    const result = (await lastValueFrom(interceptor.intercept(context, handler))) as Record<string, unknown>;
+
+    expect(result['traceId']).toBe('my-trace-id-456');
+  });
+
+  it('should use empty string for traceId when header is absent', async () => {
+    const request = {
+      method: 'GET',
+      originalUrl: '/api/test',
+      headers: {},
+    };
+    const response = { statusCode: 200 };
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+    } as unknown as ExecutionContext;
+    const handler = createMockCallHandler({});
+
+    const result = (await lastValueFrom(interceptor.intercept(context, handler))) as Record<string, unknown>;
+
+    expect(result['traceId']).toBe('');
+  });
+
+  it('should include the correct path from request.originalUrl', async () => {
+    const context = createMockExecutionContext({ url: '/api/v1/products/42', statusCode: 200 });
+    const handler = createMockCallHandler({});
+
+    const result = (await lastValueFrom(interceptor.intercept(context, handler))) as Record<string, unknown>;
+
+    expect(result['path']).toBe('/api/v1/products/42');
+  });
+
+  it('should include the correct statusCode from response', async () => {
+    const context = createMockExecutionContext({ statusCode: 201 });
+    const handler = createMockCallHandler({ id: 'abc' });
+
+    const result = (await lastValueFrom(interceptor.intercept(context, handler))) as Record<string, unknown>;
+
+    expect(result['statusCode']).toBe(201);
+  });
+
+  it('should call next.handle()', async () => {
+    const context = createMockExecutionContext({});
+    const handler = createMockCallHandler();
+
+    await lastValueFrom(interceptor.intercept(context, handler));
+
+    expect(handler.handle).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Wrap all successful responses in `{ traceId, statusCode, timestamp, path, ok, result }` envelope via a global interceptor. This aligns success responses with the error envelope already produced by `AllExceptionsFilter`.

Ported from `investment-open-api` commit `ba95ea6f`.

## Changes

| File | Description |
|---|---|
| `src/shared/interceptors/CoreResponseInterceptor.ts` | New interceptor — wraps handler return value in the standard envelope. `204 No Content` responses are exempt per HTTP spec. |
| `src/shared/interceptors/test/CoreResponseInterceptor.spec.ts` | 13 test cases covering envelope fields, 204 bypass, null/undefined coalescing, traceId extraction. |
| `src/main.ts` | Register `CoreResponseInterceptor` globally before `HttpLoggingInterceptor`. |

## Notes

- No controller response DTOs exist yet in this starter project, so the DTO restructuring part of the original commit does not apply. Future DTOs should nest business fields inside a typed `result` property (e.g. `XxxControllerResponseResult` class) so Swagger documentation matches the runtime envelope.
- `CoreResponseInterceptor` is registered **before** `HttpLoggingInterceptor` so logging captures the final envelope shape.