### PR TITLE
Prevent stale Docker builds and fix production start

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@ coverage
 migrations
 scheme
 .git
+dist
 *.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:local:dev": "NODE_ENV=local_development nest start --watch",
     "start:local:prod": "NODE_ENV=local_production nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "NODE_ENV=production node dist/main",
     "lint:check": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",


### PR DESCRIPTION
## Changes

### 1. Add `dist` to `.dockerignore`

The multi-stage `Dockerfile` runs `nest build` inside the builder stage to produce `dist/`. Without `dist` in `.dockerignore`, a stale host `dist/` directory gets copied into the image during `COPY . .`, potentially overriding or conflicting with the freshly built output. This causes the container to run outdated compiled code across rebuilds.

### 2. Add `NODE_ENV=production` to `start:prod`

`config.ts` calls `required('NODE_ENV')` which crashes at startup if `NODE_ENV` is not set. All other start scripts already set their respective `NODE_ENV` (`start:local`, `start:local:dev`, `start:local:prod`), but `start:prod` was missing it.

In container orchestration environments (ECS, k8s), `NODE_ENV` is injected via environment variables so production deployments are unaffected. However, running `npm run start:prod` locally to test a production build would crash without this fix.