### PR TITLE
Add tests for RedisCacheModule and MethodCache failure paths

### DIFF
--- a/src/shared/cache/test/RedisCacheDecorator.spec.ts
+++ b/src/shared/cache/test/RedisCacheDecorator.spec.ts
@@ -43,6 +43,24 @@ function createTestService(client: CacheClient) {
   return new TestService();
 }
 
+/** Each caller must pass a unique `prefix`: the inflight registry is shared process-wide. */
+function createSpyService(
+  client: CacheClient,
+  spy: jest.Mock,
+  prefix: string,
+): { getData(key: string): Promise<unknown> } {
+  class TestService {
+    [CACHE_CLIENT] = client;
+
+    @MethodCache({ prefix, ttlSeconds: 60 })
+    async getData(key: string): Promise<unknown> {
+      return spy(key);
+    }
+  }
+
+  return new TestService();
+}
+
 describe('MethodCache', () => {
   describe('cache hit', () => {
     it('should return cached value without calling the original method', async () => {
@@ -193,6 +211,189 @@ describe('MethodCache', () => {
         id: '1',
         name: 'User 1',
       });
+    });
+  });
+
+  describe('coalescing failure paths', () => {
+    it('should propagate the same error to every concurrent waiter', async () => {
+      const client = createMockClient();
+      const spy = jest.fn().mockRejectedValue(new Error('DB_FAIL'));
+      const service = createSpyService(client, spy, 'coalesce-error');
+
+      const results = await Promise.allSettled([
+        service.getData('k'),
+        service.getData('k'),
+        service.getData('k'),
+      ]);
+
+      for (const result of results) {
+        expect(result.status).toBe('rejected');
+        if (result.status === 'rejected') {
+          expect((result.reason as Error).message).toBe('DB_FAIL');
+        }
+      }
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not cache the result when the method rejects', async () => {
+      const client = createMockClient();
+      const spy = jest.fn().mockRejectedValue(new Error('DB_FAIL'));
+      const service = createSpyService(client, spy, 'coalesce-no-cache');
+
+      await expect(service.getData('k')).rejects.toThrow('DB_FAIL');
+
+      expect(client.set).not.toHaveBeenCalled();
+      expect(client.sadd).not.toHaveBeenCalled();
+    });
+
+    it('should clean up inflight after a rejection so the next call retries', async () => {
+      const client = createMockClient();
+      const spy = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('DB_FAIL'))
+        .mockResolvedValueOnce({ ok: true });
+      const service = createSpyService(client, spy, 'retry-after-failure');
+
+      await expect(service.getData('k')).rejects.toThrow('DB_FAIL');
+      await expect(service.getData('k')).resolves.toEqual({ ok: true });
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clean up inflight after success so a later cache miss re-executes', async () => {
+      const client = createMockClient();
+      const spy = jest.fn().mockResolvedValue({ ok: true });
+      const service = createSpyService(client, spy, 'retry-after-success');
+
+      await service.getData('k');
+      await service.getData('k');
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clean up inflight when the cache write fails', async () => {
+      const client = createMockClient({
+        set: jest.fn().mockRejectedValue(new Error('Redis write failed')),
+      });
+      const spy = jest.fn().mockResolvedValue({ ok: true });
+      const service = createSpyService(client, spy, 'retry-after-set-failure');
+
+      await expect(service.getData('k')).resolves.toEqual({ ok: true });
+      await expect(service.getData('k')).resolves.toEqual({ ok: true });
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('independent cache keys', () => {
+    it('should execute concurrent calls with different keys independently', async () => {
+      const client = createMockClient();
+      const spy = jest.fn().mockImplementation((key: string) => Promise.resolve({ key }));
+      const service = createSpyService(client, spy, 'independent');
+
+      const [first, second] = await Promise.all([
+        service.getData('a'),
+        service.getData('b'),
+      ]);
+
+      expect(first).toEqual({ key: 'a' });
+      expect(second).toEqual({ key: 'b' });
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should write a separate cache entry per key', async () => {
+      const client = createMockClient();
+      const spy = jest.fn().mockImplementation((key: string) => Promise.resolve({ key }));
+      const service = createSpyService(client, spy, 'independent-keys');
+
+      await Promise.all([service.getData('a'), service.getData('b')]);
+
+      expect(client.set).toHaveBeenCalledWith(
+        'independent-keys:a',
+        JSON.stringify({ key: 'a' }),
+        60,
+      );
+      expect(client.set).toHaveBeenCalledWith(
+        'independent-keys:b',
+        JSON.stringify({ key: 'b' }),
+        60,
+      );
+    });
+  });
+
+  describe('corrupt cached value', () => {
+    it('should fall back to the original method when cached JSON is malformed', async () => {
+      const client = createMockClient({
+        get: jest.fn().mockResolvedValue('not-valid-json{{{'),
+      });
+      const spy = jest.fn().mockResolvedValue({ ok: true });
+      const service = createSpyService(client, spy, 'corrupt');
+
+      const result = await service.getData('k');
+
+      expect(result).toEqual({ ok: true });
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should overwrite the corrupt entry with the fresh result', async () => {
+      const client = createMockClient({
+        get: jest.fn().mockResolvedValue('not-valid-json{{{'),
+      });
+      const spy = jest.fn().mockResolvedValue({ ok: true });
+      const service = createSpyService(client, spy, 'corrupt-overwrite');
+
+      await service.getData('k');
+
+      expect(client.set).toHaveBeenCalledWith(
+        'corrupt-overwrite:k',
+        JSON.stringify({ ok: true }),
+        60,
+      );
+    });
+
+    it('should fall back to the original method when a custom deserializer throws', async () => {
+      const client = createMockClient({
+        get: jest.fn().mockResolvedValue(JSON.stringify({ ok: true })),
+      });
+      const spy = jest.fn().mockResolvedValue({ ok: 'from-origin' });
+
+      class TestService {
+        [CACHE_CLIENT] = client;
+
+        @MethodCache({
+          prefix: 'bad-deserializer',
+          ttlSeconds: 60,
+          deserialize: () => {
+            throw new Error('deserialize blew up');
+          },
+        })
+        async getData(key: string): Promise<unknown> {
+          return spy(key);
+        }
+      }
+
+      const result = await new TestService().getData('k');
+
+      expect(result).toEqual({ ok: 'from-origin' });
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('null return values', () => {
+    it('should cache a null result and serve it from cache without re-executing', async () => {
+      const client = createMockClient();
+      const spy = jest.fn().mockResolvedValue(null);
+      const service = createSpyService(client, spy, 'nullable');
+
+      const firstResult = await service.getData('k');
+      expect(firstResult).toBeNull();
+      expect(client.set).toHaveBeenCalledWith('nullable:k', 'null', 60);
+
+      (client.get as jest.Mock).mockResolvedValue('null');
+      const secondResult = await service.getData('k');
+
+      expect(secondResult).toBeNull();
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/shared/cache/test/RedisCacheModule.spec.ts
+++ b/src/shared/cache/test/RedisCacheModule.spec.ts
@@ -1,0 +1,143 @@
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { RedisCacheModule } from '../RedisCacheModule';
+import { CacheClient, CACHE_CLIENT } from '../interfaces';
+
+function createMockClient(overrides: Partial<CacheClient> = {}): CacheClient {
+  return {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+    sadd: jest.fn().mockResolvedValue(undefined),
+    smembers: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe('RedisCacheModule', () => {
+  describe('forRoot with a provided client', () => {
+    it('should expose the provided client under the CACHE_CLIENT token', async () => {
+      const client = createMockClient();
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [RedisCacheModule.forRoot({ client })],
+      }).compile();
+
+      expect(moduleRef.get<CacheClient>(CACHE_CLIENT)).toBe(client);
+    });
+
+    it('should not emit a warning when a client is provided', () => {
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      RedisCacheModule.forRoot({ client: createMockClient() });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('forRoot without a client (no-op fallback)', () => {
+    it('should fall back to a no-op client when no client is given', async () => {
+      jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [RedisCacheModule.forRoot()],
+      }).compile();
+
+      const client = moduleRef.get<CacheClient>(CACHE_CLIENT);
+
+      expect(client).toBeDefined();
+
+      jest.restoreAllMocks();
+    });
+
+    it('should fall back to a no-op client when options omit the client key', async () => {
+      jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [RedisCacheModule.forRoot({})],
+      }).compile();
+
+      expect(moduleRef.get<CacheClient>(CACHE_CLIENT)).toBeDefined();
+
+      jest.restoreAllMocks();
+    });
+
+    it('should warn that caching is disabled', () => {
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      RedisCacheModule.forRoot();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('caching is disabled'));
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('no-op client behaviour', () => {
+    let client: CacheClient;
+
+    beforeEach(async () => {
+      jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [RedisCacheModule.forRoot()],
+      }).compile();
+
+      client = moduleRef.get<CacheClient>(CACHE_CLIENT);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should always return null from get, so every lookup is a cache miss', async () => {
+      await expect(client.get('any-key')).resolves.toBeNull();
+    });
+
+    it('should return null from get even after a set', async () => {
+      await client.set('key', 'value', 60);
+
+      await expect(client.get('key')).resolves.toBeNull();
+    });
+
+    it('should resolve set without throwing', async () => {
+      await expect(client.set('key', 'value', 60)).resolves.toBeUndefined();
+    });
+
+    it('should resolve del without throwing', async () => {
+      await expect(client.del(['key-a', 'key-b'])).resolves.toBeUndefined();
+    });
+
+    it('should resolve sadd without throwing', async () => {
+      await expect(client.sadd('registry', 'key-a')).resolves.toBeUndefined();
+    });
+
+    it('should always return an empty array from smembers', async () => {
+      await client.sadd('registry', 'key-a');
+
+      await expect(client.smembers('registry')).resolves.toEqual([]);
+    });
+  });
+
+  describe('dynamic module shape', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should be registered as a global module', () => {
+      const dynamicModule = RedisCacheModule.forRoot({ client: createMockClient() });
+
+      expect(dynamicModule.global).toBe(true);
+      expect(dynamicModule.module).toBe(RedisCacheModule);
+    });
+
+    it('should export the CACHE_CLIENT token', () => {
+      const dynamicModule = RedisCacheModule.forRoot({ client: createMockClient() });
+
+      expect(dynamicModule.exports).toContain(CACHE_CLIENT);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Close the remaining test coverage gaps in `src/shared/cache/`, introduced in #142. `RedisCacheModule` had no tests at all, and `MethodCache` covered only the success path — leaving the error handling that a future stale-while-revalidate change would touch unverified.

Cache suite goes from 30 to 54 tests. No source files changed.

## Changes

| File | Description |
|---|---|
| `src/shared/cache/test/RedisCacheModule.spec.ts` | New — 13 cases. Covers `forRoot()` with and without an injected client, resolving `CACHE_CLIENT` through the Nest DI container rather than asserting on the `DynamicModule` literal alone. Also covers the no-op fallback that silently disables caching (`get` always returns `null` so every lookup is a miss, `smembers` always returns `[]` so invalidation finds no keys). |
| `src/shared/cache/test/RedisCacheDecorator.spec.ts` | 11 cases added. Inflight cleanup on rejection and on failed cache writes, corrupt cached values falling back to the origin, independent keys writing separate entries, and `null` results round tripping through the cache. |

## Notes

- The two behaviours most likely to regress were confirmed by mutation testing rather than assumed. Removing the `finally` cleanup in `MethodCache` fails 3 of the new inflight tests (plus 1 pre-existing coalescing test); moving `deserialize` outside the `try` block fails all 3 corrupt-value tests. The source was restored byte-identical afterwards — `git status` shows test files only.
- `inflightRequests` is a module-level `Map` shared process-wide, so two services registering the same `prefix` would coalesce requests across service boundaries. The new tests work around this with a unique prefix per case. Left unchanged here since it is a design question rather than a test gap, but it is worth resolving alongside any stale-while-revalidate work, which would touch the same inflight logic.
